### PR TITLE
Correct login error message

### DIFF
--- a/lndb_setup/_setup_user.py
+++ b/lndb_setup/_setup_user.py
@@ -74,7 +74,7 @@ def login(
     if user_settings.password is None:
         raise RuntimeError(
             "No stored user password, please call: lndb login --email <your-email>"
-            " --email <your-password>"
+            " --password <your-password>"
         )
 
     response = sign_in_hub(


### PR DESCRIPTION
It seems there is a wrong argument name in the login error message.