### PR TITLE
Enable to read settings from database

### DIFF
--- a/lndb_setup/__init__.py
+++ b/lndb_setup/__init__.py
@@ -40,7 +40,7 @@ Dev API
 __version__ = "0.8.2"
 from . import _check_versions  # noqa
 from ._schema import schema  # noqa
-from ._settings import settings  # noqa
+from ._settings import settings_from_env  # noqa
 from ._settings_instance import InstanceSettings, Storage  # noqa
 from ._settings_user import UserSettings  # noqa
 from ._setup_instance import init, load  # noqa

--- a/lndb_setup/_setup_instance.py
+++ b/lndb_setup/_setup_instance.py
@@ -69,9 +69,9 @@ def load(instance_name: str):
     assert isettings.name is not None
     save_instance_settings(isettings)
 
-    from ._settings import settings
+    from ._settings import settings_from_env
 
-    settings._instance_settings = None
+    settings_from_env._instance_settings = None
 
     message = check_migrate(usettings=usettings, isettings=isettings)
     if message == "migrate-failed":
@@ -132,7 +132,7 @@ def init(
 
     setup_instance_db()
 
-    from ._settings import settings
+    from ._settings import settings_from_env
 
-    settings._instance_settings = None
+    settings_from_env._instance_settings = None
     return None

--- a/lndb_setup/_setup_user.py
+++ b/lndb_setup/_setup_user.py
@@ -47,9 +47,9 @@ def load_user(email: str = None, handle: str = None):
         user_settings.handle = handle
         save_user_settings(user_settings)
 
-    from ._settings import settings
+    from ._settings import settings_from_env
 
-    settings._user_settings = None  # this is to refresh a settings instance
+    settings_from_env._user_settings = None  # this is to refresh a settings instance
 
 
 def login(
@@ -93,21 +93,21 @@ def login(
     user_settings.handle = user_handle
     save_user_settings(user_settings)
 
-    from ._settings import settings
+    from ._settings import settings_from_env
 
-    settings._user_settings = None
+    settings_from_env._user_settings = None
 
     # log in user into instance db
-    if settings.instance.name is not None:
+    if settings_from_env.instance.name is not None:
         # the above if condition is not safe enough
         # users might delete a database but still keeping the
         # current_instance.env settings file around
         # hence, the if condition will pass despite the database
         # having actually been deleted
         # so, let's do another check
-        if settings.instance._dbconfig == "sqlite":
+        if settings_from_env.instance._dbconfig == "sqlite":
             # let's check whether the sqlite file is actually available
-            if not settings.instance._sqlite_file.exists():
+            if not settings_from_env.instance._sqlite_file.exists():
                 # if the file doesn't exist, there is no need to
                 # log in the user
                 # hence, simply end log in here
@@ -115,9 +115,9 @@ def login(
             # if the file exists but does not have a user table, raise a warning
             if "user" not in schema.list_entities():
                 logger.warning(
-                    f"An SQLite file {settings.instance._sqlite_file} exists but does not have a user table. "  # noqa
+                    f"An SQLite file {settings_from_env.instance._sqlite_file} exists but does not have a user table. "  # noqa
                 )
                 return None
         insert_if_not_exists.user(
-            settings.user.email, settings.user.id, settings.user.handle
+            settings_from_env.user.email, settings_from_env.user.id, settings_from_env.user.handle
         )


### PR DESCRIPTION
The SettingsManager class (we certainly want to rename it Settings) has to enable to use settings coming from env file as well as database, depending of the value of LAMIN_SETTING_SOURCE env variable.