### PR TITLE
:construction: Enable other settings location

### DIFF
--- a/lndb_setup/_settings_store.py
+++ b/lndb_setup/_settings_store.py
@@ -5,8 +5,8 @@ from pydantic import BaseSettings
 
 
 def get_settings_dir():
-    if ('LAMIN_BASE_SETTINGS_DIR' in os.environ):
-        return os.environ['LAMIN_BASE_SETTINGS_DIR'] / ".lndb"
+    if "LAMIN_BASE_SETTINGS_DIR" in os.environ:
+        return os.environ["LAMIN_BASE_SETTINGS_DIR"] / ".lndb"
     else:
         return Path.home() / ".lndb"
 


### PR DESCRIPTION
This is necessary to deploy lndb-rest on aws lamda because we can't write outside /tmp folder.
