### PR TITLE
:bug: Redirect user after signup

### DIFF
--- a/lndb_setup/_hub.py
+++ b/lndb_setup/_hub.py
@@ -20,7 +20,9 @@ def connect_hub():
 def sign_up_hub(email) -> Union[str, None]:
     hub = connect_hub()
     password = id.id_secret()  # generate new password
-    user = hub.auth.sign_up(email=email, password=password)
+    user = hub.auth.sign_up(
+        email=email, password=password, redirect_to="https://lamin.ai/signup"
+    )
     # if user already exists a fake user object without identity is returned
     if user.identities:
         # if user had called sign-up before, but not confirmed their email


### PR DESCRIPTION
@Alex If just want the user to set his handle, I would rather redirect him on this page https://lamin.ai/signup.
What do you think ? 

Not sure why it was not working, I don't remember we had to pass a redirect argument to signup.
I though this was on option in Supabase UI, but it doesn't seems to exists anymore.