### PR TITLE
✨ Enable to skip migration

### DIFF
--- a/lndb_setup/_migrate.py
+++ b/lndb_setup/_migrate.py
@@ -18,7 +18,7 @@ def check_migrate(
     usettings: UserSettings,
     isettings: InstanceSettings,
 ):
-    if "LAMIN_SKIP_MIGRATION" not in os.environ:
+    if "LAMIN_SKIP_MIGRATION" in os.environ:
         if os.environ["LAMIN_SKIP_MIGRATION"] == "true":
             return "migrate-failed"
 


### PR DESCRIPTION
Automatic migration seems to bring some problems in the deployment of rest APIs using lamindb.
As a solution, we introduce a new environment variable that will enable to skip migration.
@falexwolf are you ok with that ?