### PR TITLE
:bug: Fix wrong instance settings

### DIFF
--- a/lndb_setup/_setup_instance.py
+++ b/lndb_setup/_setup_instance.py
@@ -72,7 +72,7 @@ def persist_check_reload_schema(isettings: InstanceSettings):
     # check whether we're switching from sqlite to postgres or vice versa
     # if we do, we need to re-import the schema modules to account for differences
     check = False
-    if instance_exists(isettings):
+    if settings._instance_exists:
         if isettings._dbconfig == "sqlite" and isettings._dbconfig != "sqlite":
             check = True
         if isettings._dbconfig != "sqlite" and isettings._dbconfig == "sqlite":


### PR DESCRIPTION
I run into some problems when writing some test for #174. 
Seems this [statement](https://github.com/laminlabs/lndb-setup/pull/176/files#diff-c0bacc9350715f7dda059501091792d96729696aa19135862de361765ff1da6fL75) reference another instance that the one I tried to create.
Maybe I'm wrong but this lead me to think that there is a misusage of `settings`.

Here is the executed command:

```
pgurl = setup_local_test_postgres("pgtest_remote_storage")
init(storage="s3://lndb-setup-ci-pgtest-remote", url=pgurl, name="pgtest_remote_storage")
```

Here is the error output:

```
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
File ~/opt/anaconda3/lib/python3.9/pathlib.py:1323, in Path.mkdir(self, mode, parents, exist_ok)
   1322 try:
-> 1323     self._accessor.mkdir(self, mode)
   1324 except FileNotFoundError:

FileNotFoundError: [Errno 2] No such file or directory: '/Users/falexwolf/repos/lndb-setup/docs/guide/pgtest'

During handling of the above exception, another exception occurred:

FileNotFoundError                         Traceback (most recent call last)
File ~/opt/anaconda3/lib/python3.9/pathlib.py:1323, in Path.mkdir(self, mode, parents, exist_ok)
   1322 try:
-> 1323     self._accessor.mkdir(self, mode)
   1324 except FileNotFoundError:

FileNotFoundError: [Errno 2] No such file or directory: '/Users/falexwolf/repos/lndb-setup/docs/guide'

During handling of the above exception, another exception occurred:

FileNotFoundError                         Traceback (most recent call last)
File ~/opt/anaconda3/lib/python3.9/pathlib.py:1323, in Path.mkdir(self, mode, parents, exist_ok)
   1322 try:
-> 1323     self._accessor.mkdir(self, mode)
   1324 except FileNotFoundError:

FileNotFoundError: [Errno 2] No such file or directory: '/Users/falexwolf/repos/lndb-setup/docs'

During handling of the above exception, another exception occurred:

FileNotFoundError                         Traceback (most recent call last)
File ~/opt/anaconda3/lib/python3.9/pathlib.py:1323, in Path.mkdir(self, mode, parents, exist_ok)
   1322 try:
-> 1323     self._accessor.mkdir(self, mode)
   1324 except FileNotFoundError:

FileNotFoundError: [Errno 2] No such file or directory: '/Users/falexwolf/repos/lndb-setup'

During handling of the above exception, another exception occurred:

FileNotFoundError                         Traceback (most recent call last)
File ~/opt/anaconda3/lib/python3.9/pathlib.py:1323, in Path.mkdir(self, mode, parents, exist_ok)
   1322 try:
-> 1323     self._accessor.mkdir(self, mode)
   1324 except FileNotFoundError:

FileNotFoundError: [Errno 2] No such file or directory: '/Users/falexwolf/repos'

During handling of the above exception, another exception occurred:

PermissionError                           Traceback (most recent call last)
/Users/fredericenard/Sources/lamin/lndb-setup/docs/guide/8-load.ipynb Cellule 11 in <cell line: 1>()
----> [1](vscode-notebook-cell:/Users/fredericenard/Sources/lamin/lndb-setup/docs/guide/8-load.ipynb#X23sZmlsZQ%3D%3D?line=0) init(storage="s3://lndb-setup-ci-pgtest-remote", url=pgurl)

File ~/Sources/lamin/lndb-setup/lndb_setup/_setup_instance.py:165, in init(storage, url, schema, migrate, name)
    155 storage_root = setup_storage_root(storage)
    156 isettings = InstanceSettings(
    157     storage_root=storage_root,
    158     storage_region=get_storage_region(storage_root),
   (...)
    162     owner=settings.user.handle,
    163 )
--> 165 persist_check_reload_schema(isettings)
    166 if instance_exists(isettings):
    167     return load(isettings.name, isettings.owner, migrate=migrate)

File ~/Sources/lamin/lndb-setup/lndb_setup/_setup_instance.py:75, in persist_check_reload_schema(isettings)
     71 def persist_check_reload_schema(isettings: InstanceSettings):
     72     # check whether we're switching from sqlite to postgres or vice versa
     73     # if we do, we need to re-import the schema modules to account for differences
     74     check = False
---> 75     if settings._instance_exists:
     76         if settings.instance._dbconfig == "sqlite" and isettings._dbconfig != "sqlite":
     77             check = True

File ~/Sources/lamin/lndb-setup/lndb_setup/_settings.py:16, in classproperty.__get__(self, owner_self, owner_cls)
     14 def __get__(self, owner_self, owner_cls):
     15     """Get."""
---> 16     return self.fget(owner_cls)

File ~/Sources/lamin/lndb-setup/lndb_setup/_settings.py:59, in settings._instance_exists(cls)
     56 @classproperty
     57 def _instance_exists(cls):
     58     try:
---> 59         cls.instance
     60         return True
     61     except RuntimeError:

File ~/Sources/lamin/lndb-setup/lndb_setup/_settings.py:16, in classproperty.__get__(self, owner_self, owner_cls)
     14 def __get__(self, owner_self, owner_cls):
     15     """Get."""
---> 16     return self.fget(owner_cls)

File ~/Sources/lamin/lndb-setup/lndb_setup/_settings.py:52, in settings.instance(cls)
     47 """Instance-related settings."""
     48 if (
     49     cls._instance_settings is None
     50     or cls._instance_settings_env != get_env_name()  # noqa
     51 ):
---> 52     cls._instance_settings = load_instance_settings()
     53     cls._instance_settings_env = get_env_name()
     54 return cls._instance_settings

File ~/Sources/lamin/lndb-setup/lndb_setup/_settings_load.py:29, in load_instance_settings(instance_settings_file)
     24 except ValidationError:
     25     raise RuntimeError(
     26         "Your instance settings file is invalid, please delete"
     27         f" {instance_settings_file} and init the instance again."
     28     )
---> 29 isettings = setup_instance_from_store(settings_store)
     30 return isettings

File ~/Sources/lamin/lndb-setup/lndb_setup/_settings_load.py:80, in setup_instance_from_store(store)
     76 def setup_instance_from_store(store: InstanceSettingsStore) -> InstanceSettings:
     77     return InstanceSettings(
     78         owner=store.owner,
     79         name=store.name,
---> 80         storage_root=setup_storage_root(store.storage_root),
     81         url=store.url if store.url != "null" else None,
     82         _schema=store.schema_,
     83         storage_region=store.storage_region,
     84     )

File ~/Sources/lamin/lndb-setup/lndb_setup/_settings_load.py:72, in setup_storage_root(storage)
     70 else:  # local path
     71     storage_root = Path(storage).absolute()
---> 72     storage_root.mkdir(parents=True, exist_ok=True)
     73 return storage_root

File ~/opt/anaconda3/lib/python3.9/pathlib.py:1327, in Path.mkdir(self, mode, parents, exist_ok)
   1325     if not parents or self.parent == self:
   1326         raise
-> 1327     self.parent.mkdir(parents=True, exist_ok=True)
   1328     self.mkdir(mode, parents=False, exist_ok=exist_ok)
   1329 except OSError:
   1330     # Cannot rely on checking for EEXIST, since the operating system
   1331     # could give priority to other errors like EACCES or EROFS

File ~/opt/anaconda3/lib/python3.9/pathlib.py:1327, in Path.mkdir(self, mode, parents, exist_ok)
   1325     if not parents or self.parent == self:
   1326         raise
-> 1327     self.parent.mkdir(parents=True, exist_ok=True)
   1328     self.mkdir(mode, parents=False, exist_ok=exist_ok)
   1329 except OSError:
   1330     # Cannot rely on checking for EEXIST, since the operating system
   1331     # could give priority to other errors like EACCES or EROFS

    [... skipping similar frames: Path.mkdir at line 1327 (2 times)]

File ~/opt/anaconda3/lib/python3.9/pathlib.py:1327, in Path.mkdir(self, mode, parents, exist_ok)
   1325     if not parents or self.parent == self:
   1326         raise
-> 1327     self.parent.mkdir(parents=True, exist_ok=True)
   1328     self.mkdir(mode, parents=False, exist_ok=exist_ok)
   1329 except OSError:
   1330     # Cannot rely on checking for EEXIST, since the operating system
   1331     # could give priority to other errors like EACCES or EROFS

File ~/opt/anaconda3/lib/python3.9/pathlib.py:1323, in Path.mkdir(self, mode, parents, exist_ok)
   1319 """
   1320 Create a new directory at this given path.
   1321 """
   1322 try:
-> 1323     self._accessor.mkdir(self, mode)
   1324 except FileNotFoundError:
   1325     if not parents or self.parent == self:

PermissionError: [Errno 13] Permission denied: '/Users/falexwolf'
```