### PR TITLE
:bug: Fix `schema=None`

### DIFF
--- a/lndb_setup/_load.py
+++ b/lndb_setup/_load.py
@@ -119,11 +119,15 @@ def load_isettings_from_hub(instance_name: str, owner_handle: str):
 
     url = None if instance["dbconfig"] == "sqlite" else instance["db"]
 
+    schema = instance["schema"]
+    if schema is None:
+        schema = ""
+
     isettings = InstanceSettings(
         storage_root=setup_storage_root(storage["root"]),
         storage_region=storage["region"],
         url=url,
-        _schema=instance["schema"],
+        _schema=schema,
         name=instance["name"],
         owner=owner_handle,
     )


### PR DESCRIPTION
When loading from the hub i had `_schema=None` in the `isettings` as a result, which threw an error later in the `init` on trying to access `isettings.schema` as `None` doesn't have `split`.