### PR TITLE
✨ Add root_str property to Storage

### DIFF
--- a/lndb/dev/_storage.py
+++ b/lndb/dev/_storage.py
@@ -36,6 +36,15 @@ class Storage:
         return self._root
 
     @property
+    def root_str(self) -> str:
+        """Formatted root string."""
+        root_str = self.root.as_posix()
+        if root_str[-1] == "/":
+            return root_str[:-1]
+        else:
+            return root_str
+
+    @property
     def cache_dir(
         self,
     ) -> Union[Path, None]:


### PR DESCRIPTION
Converts `Storage.root` to a posix string and removes the trailing slash.