### PR TITLE
🚸 Simplify remote SQLite synching & locking

### DIFF
--- a/docs/faq/test-sqlite-sync.ipynb
+++ b/docs/faq/test-sqlite-sync.ipynb
@@ -75,6 +75,82 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "45967bdd",
+   "metadata": {},
+   "source": [
+    "Remote SQLite file does not yet exist upon instance init:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "037ac4f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert not settings.instance._sqlite_file.exists()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "5d253504",
+   "metadata": {},
+   "source": [
+    "Create it (the user only ever calls this implicitly through `lamin close`). This runs 9s!!!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a3cd72d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "settings.instance._update_cloud_sqlite_file()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81100c7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert settings.instance._sqlite_file.exists()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "c764511d",
+   "metadata": {},
+   "source": [
+    "Now mimic a new user who loads the instance (this runs 4s):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01ef82da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "settings.instance._update_local_sqlite_file()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "8e39b443",
+   "metadata": {},
+   "source": [
+    "Get the mere filepath of the local file, without any update:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "7b5a850a",
@@ -100,7 +176,7 @@
    "id": "26d8bd48",
    "metadata": {},
    "source": [
-    "Delete the local sqlite database file."
+    "Delete the local sqlite file:"
    ]
   },
   {

--- a/lamindb_setup/_close.py
+++ b/lamindb_setup/_close.py
@@ -13,6 +13,7 @@ def close() -> None:
     """
     if current_instance_settings_file().exists():
         instance = settings.instance.identifier
+        settings.instance._update_cloud_sqlite_file()
         current_instance_settings_file().unlink()
         os.environ["LAMINDB_INSTANCE_LOADED"] = "0"
         logger.success(f"Closed {instance}")

--- a/lamindb_setup/_delete.py
+++ b/lamindb_setup/_delete.py
@@ -3,9 +3,10 @@ from pathlib import Path
 
 from lamin_logger import logger
 
+from ._close import close
 from ._settings import settings
 from .dev._settings_load import load_instance_settings
-from .dev._settings_store import current_instance_settings_file, instance_settings_file
+from .dev._settings_store import instance_settings_file
 
 
 def delete(instance_name: str):
@@ -24,16 +25,9 @@ def delete(instance_name: str):
     delete_settings(settings_file)
     if settings._instance_exists:
         if instance_identifier == settings.instance.identifier:
-            current_settings_file = current_instance_settings_file()
-            logger.info(
-                f"    current instance settings {current_settings_file} deleted"
-            )
-            current_settings_file.unlink()
+            close()  # close() does further operations, unlocking...
             settings._instance_settings = None
     delete_cache(isettings.storage.cache_dir)
-    logger.info(
-        f"    consider deleting your stored data manually: {isettings.storage.root}"
-    )
     if isettings.dialect == "sqlite":
         if isettings._sqlite_file.exists():
             isettings._sqlite_file.unlink()
@@ -41,7 +35,8 @@ def delete(instance_name: str):
         else:
             logger.info("    '.lndb' sqlite file does not exist")
     if isettings.is_remote:
-        logger.info("    please manually delete your remote instance on lamin.ai")
+        logger.info("    manually delete your remote instance on lamin.ai")
+    logger.info(f"    manually delete your stored data: {isettings.storage.root}")
 
 
 def delete_cache(cache_dir: Path):
@@ -53,6 +48,6 @@ def delete_cache(cache_dir: Path):
 def delete_settings(settings_file: Path):
     if settings_file.exists():
         settings_file.unlink()
-        logger.info("    instance settings '.env' deleted")
+        logger.info(f"    deleted instance settings file: {settings_file}")
     else:
-        logger.info("    instance settings '.env' do not exist locally")
+        logger.info(f"    instance settings file doesn't exist: {settings_file}")

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -188,7 +188,11 @@ def init(
         load_schema(isettings, init=True)
         register(isettings, settings.user)  # if this doesn't emit warning, we're good
         write_bionty_versions(isettings)
-        isettings._update_cloud_sqlite_file()
+        if isettings._is_cloud_sqlite:
+            logger.hint("To push changes to the cloud SQLite file, call: lamin close")
+            logger.hint(
+                f"In the meantime, {isettings._sqlite_file} is locked for other users"
+            )
     else:
         # we're currently using this for testing migrations
         # passing connection strings of databases that need to be tested

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -9,7 +9,7 @@ from pydantic import PostgresDsn
 from lamindb_setup.dev.upath import UPath
 
 from ._docstrings import instance_description as description
-from ._load_instance import load, load_from_isettings
+from ._load_instance import load
 from ._settings import settings
 from .dev import InstanceSettings
 from .dev._docs import doc_args
@@ -184,23 +184,17 @@ def init(
         isettings._persist()
         return None
 
-    if not isettings._is_db_setup(mute=True)[0]:
-        load_schema(isettings, init=True)
-        register(isettings, settings.user)  # if this doesn't emit warning, we're good
-        write_bionty_versions(isettings)
-        if isettings._is_cloud_sqlite:
-            logger.hint("To push changes to the cloud SQLite file, call: lamin close")
-            logger.hint(
-                f"In the meantime, {isettings._sqlite_file} is locked for other users"
-            )
-    else:
-        # we're currently using this for testing migrations
-        # passing connection strings of databases that need to be tested
-        # for migrations
-        logger.warning("Your instance seems already set up, attempt load:")
-        load_from_isettings(isettings, migrate=_migrate)
-
-    isettings._persist()
+    assert not isettings._is_db_setup(mute=True)[0]
+    load_schema(isettings, init=True)
+    register(isettings, settings.user)  # if this doesn't emit warning, we're good
+    write_bionty_versions(isettings)
+    if isettings._is_cloud_sqlite:
+        logger.hint("To push changes to the cloud SQLite file, call: lamin close")
+        # @Sergei, this is currently not yet enabled
+        # logger.hint(
+        #     f"In the meantime, {isettings._sqlite_file} is locked for other users"
+        # )
+    isettings._persist()  # we're now good to write non-corrupted settings
     reload_lamindb(isettings)
 
 

--- a/lamindb_setup/_load_instance.py
+++ b/lamindb_setup/_load_instance.py
@@ -72,8 +72,7 @@ def load(
         isettings._persist()  # this is to test the settings
         return None
 
-    isettings._update_local_sqlite_file()
-    check, msg = isettings._is_db_setup()
+    check, msg = isettings._is_db_setup()  # this also updates local SQLite
     if not check:
         if _log_error_message:
             raise RuntimeError(msg)

--- a/lamindb_setup/_load_instance.py
+++ b/lamindb_setup/_load_instance.py
@@ -72,6 +72,7 @@ def load(
         isettings._persist()  # this is to test the settings
         return None
 
+    isettings._update_local_sqlite_file()
     check, msg = isettings._is_db_setup()
     if not check:
         if _log_error_message:

--- a/lamindb_setup/dev/_django.py
+++ b/lamindb_setup/dev/_django.py
@@ -64,7 +64,7 @@ def setup_django(
             if deploy_migrations:
                 verbosity = 0 if init else 2
                 call_command("migrate", verbosity=verbosity)
-                if not init:  # delay sync
+                if not init:  # only update if this is a deploy migration command
                     isettings._update_cloud_sqlite_file()
             else:
                 logger.warning(

--- a/lamindb_setup/dev/_exclusion.py
+++ b/lamindb_setup/dev/_exclusion.py
@@ -155,11 +155,11 @@ class Locker:
 _locker: Optional[Locker] = None
 
 
-def get_locker() -> Locker:
+def get_locker(isettings) -> Locker:
     from .._settings import settings
 
     user_id = settings.user.id
-    storage_root = settings.instance.storage.root
+    storage_root = isettings.storage.root
 
     global _locker
 

--- a/lamindb_setup/dev/_exclusion.py
+++ b/lamindb_setup/dev/_exclusion.py
@@ -6,6 +6,7 @@ import fsspec
 from dateutil.parser import isoparse  # type: ignore
 from lamin_logger import logger
 
+from ._settings_instance import InstanceSettings
 from .upath import UPath
 from .upath import infer_filesystem as _infer_filesystem
 
@@ -155,7 +156,7 @@ class Locker:
 _locker: Optional[Locker] = None
 
 
-def get_locker(isettings) -> Locker:
+def get_locker(isettings: InstanceSettings) -> Locker:
     from .._settings import settings
 
     user_id = settings.user.id

--- a/lamindb_setup/dev/_settings_instance.py
+++ b/lamindb_setup/dev/_settings_instance.py
@@ -166,7 +166,7 @@ class InstanceSettings:
     @property
     def _cloud_sqlite_locker(self):
         if self._is_cloud_sqlite:
-            return get_locker()
+            return get_locker(self)
         else:
             return empty_locker
 

--- a/lamindb_setup/dev/_settings_instance.py
+++ b/lamindb_setup/dev/_settings_instance.py
@@ -227,6 +227,9 @@ class InstanceSettings:
             else:
                 return False, f"Connection {self.db} not reachable"
 
+        # in order to proceed with the next check, we need the local sqlite
+        self._update_local_sqlite_file()
+
         import sqlalchemy as sa
 
         engine = sa.create_engine(self.db)

--- a/lamindb_setup/dev/_settings_instance.py
+++ b/lamindb_setup/dev/_settings_instance.py
@@ -5,7 +5,6 @@ from typing import Literal, Optional, Set, Tuple, Union
 
 from lamin_logger import logger
 
-from ._exclusion import empty_locker, get_locker
 from ._settings_save import save_instance_settings
 from ._settings_store import current_instance_settings_file, instance_settings_file
 from ._storage import StorageSettings
@@ -165,6 +164,9 @@ class InstanceSettings:
 
     @property
     def _cloud_sqlite_locker(self):
+        # avoid circular import
+        from ._exclusion import empty_locker, get_locker
+
         if self._is_cloud_sqlite:
             return get_locker(self)
         else:


### PR DESCRIPTION
By having only 3 points in which we synch & lock/unlock the remote SQLite file, we can simplify the code dramatically and still create a safe & performant user experience.

The one and only downside is that the user needs to manually push changes back to the cloud by calling `lamin close`. But given this is a known journey (`git push`), it shouldn't be a big deal.

The 3 points are:
* `init` merely locks the remote sqlite file but doesn't yet upload it
* `load` synchs changes from a remote sqlite file to the local file & locks the remote file
* `close` updates the remote sqlite file & unlocks it

In this PR, we don't put forward the locking on init because it is heavily used in concurrent CI settings.

The really great thing here is that `lamindb` can be entirely free from logic around synching the cloud sqlite. It makes the code simpler and less error prone, and very performant.