### PR TITLE
🔥 Adapt locker to lock entire lamindb session

### DIFF
--- a/lamindb_setup/_load_instance.py
+++ b/lamindb_setup/_load_instance.py
@@ -81,6 +81,11 @@ def load(
             )
             return "instance-not-reachable"
 
+    # at this point the lock should be already initialized
+    if not isettings._cloud_sqlite_locker.has_lock:
+        locked_by = isettings._cloud_sqlite_locker._locked_by
+        raise RuntimeError(f"Can't load the instance, it is locked by {locked_by}.")
+
     # need to set up Django here because we query the storage table
     setup_django(isettings)
     if storage is not None and isettings.dialect == "sqlite":

--- a/lamindb_setup/dev/_settings_instance.py
+++ b/lamindb_setup/dev/_settings_instance.py
@@ -164,10 +164,10 @@ class InstanceSettings:
     @property
     def _cloud_sqlite_locker(self):
         # avoid circular import
-        from ._cloud_sqlite_locker import empty_locker
+        from ._cloud_sqlite_locker import empty_locker, get_locker
 
         if self._is_cloud_sqlite:
-            return empty_locker
+            return get_locker(self)
         else:
             return empty_locker
 


### PR DESCRIPTION
Now 
`settings.instance.cloud_sqlite_locker.lock()` doesn't lock anything by itself, it just check if it can obtain write access to the (cloud sqlite) instance.
After calling `settings.instance.cloud_sqlite_locker.lock()` at the load of an instance (internally), all write operations in lamindb should check the property `settings.instance.cloud_sqlite_locker.has_lock` before proceeding. 

upd:
Now prevents an instance from loading completely if locked by another user.