### PR TITLE
♻️ Introduce `create_path`

### DIFF
--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -16,6 +16,7 @@ from .dev import InstanceSettings
 from .dev._docs import doc_args
 from .dev._settings_storage import StorageSettings
 from .dev._setup_schema import get_schema_module_name, load_schema
+from .dev.upath import create_path
 
 
 def register_storage(ssettings: StorageSettings):
@@ -240,11 +241,7 @@ def infer_instance_name(
         # better way of accessing the database name?
         return str(db).split("/")[-1]
 
-    if isinstance(storage, str):
-        storage_path = StorageSettings._str_to_path(storage)
-    else:
-        storage_path = storage
-
+    storage_path = create_path(storage)
     if isinstance(storage_path, UPath):
         name = storage_path._url.netloc
     else:

--- a/lamindb_setup/dev/_settings_storage.py
+++ b/lamindb_setup/dev/_settings_storage.py
@@ -23,6 +23,9 @@ class StorageSettings:
         else:
             raise ValueError("root should be of type Union[str, Path, UPath].")
 
+        if isinstance(root_path, UPath):
+            root_path = create_upath(root_path)
+
         # root_path is either Path or UPath at this point
         if not isinstance(root_path, UPath):
             # resolve fails for nonexisting dir
@@ -37,7 +40,7 @@ class StorageSettings:
     @staticmethod
     def _str_to_path(storage: str) -> Union[Path, UPath]:
         if storage.startswith(("s3://", "gs://")):
-            storage_root = create_upath(storage)
+            storage_root = UPath(storage)
         else:  # local path
             storage_root = Path(storage)
         return storage_root

--- a/tests/test_load_persistent_instance.py
+++ b/tests/test_load_persistent_instance.py
@@ -7,9 +7,7 @@ import lamindb_setup as ln_setup
 
 def test_load_persistent_instance():
     ln_setup.load("testuser1/lamin-site-assets")
+    from ln_setup.dev.upath import AWS_CREDENTIALS_PRESENT
 
-    path = ln_setup.settings.storage.to_path("s3://lamin-site-assets/xyz.xyz")
-    assert path._kwargs["anon"]
-    assert path._kwargs["cache_regions"]
-
+    assert not AWS_CREDENTIALS_PRESENT
     ln_setup.close()

--- a/tests/test_load_persistent_instance.py
+++ b/tests/test_load_persistent_instance.py
@@ -6,8 +6,7 @@ import lamindb_setup as ln_setup
 
 
 def test_load_persistent_instance():
+    assert ln_setup.dev.upath.AWS_CREDENTIALS_PRESENT is None
     ln_setup.load("testuser1/lamin-site-assets")
-    from ln_setup.dev.upath import AWS_CREDENTIALS_PRESENT
-
-    assert not AWS_CREDENTIALS_PRESENT
+    assert not ln_setup.dev.upath.AWS_CREDENTIALS_PRESENT
     ln_setup.close()


### PR DESCRIPTION
- https://github.com/laminlabs/lamindb/pull/1072

This is likely not the ultimate solution, but should be good for a while.

It's hard to subclass UPath.

I think it's also overkill to create a global `Permissions` class at this point.

Essentially, it's as simple as checking whether AWS credentials are present, and that's happening now.

We could extend this to GCP & Azure if needed at some point.