### PR TITLE
🔒 Require users to provide database credentials on first loading

### DIFF
--- a/lamindb_setup/__main__.py
+++ b/lamindb_setup/__main__.py
@@ -11,6 +11,8 @@ init_help = "Init & config instance with db & storage."
 load_help = "Load instance by name."
 set_storage_help = "Set storage used by an instance."
 load_storage_help = "Load the instance with an updated default storage."
+load_db_user_help = "Load the instance with an updated db user."
+load_db_password_help = "Load the instance with an updated db password."
 info_help = "Show current instance information."
 close_help = "Close instance."
 migr_help = "Manage migrations."
@@ -43,6 +45,8 @@ The instance identifier can the instance name (owner is
 current user), handle/name, or the URL: https://lamin.ai/handle/name."""
 aa("instance", type=str, metavar="i", default=None, help=instance_help)
 aa("--storage", type=str, metavar="s", default=None, help=load_storage_help)
+aa("--db_user", type=str, metavar="s", default=None, help=load_db_user_help)
+aa("--db_password", type=str, metavar="s", default=None, help=load_db_password_help)
 
 # delete instance
 delete_parser = subparsers.add_parser("delete", help=delete_help)
@@ -141,6 +145,8 @@ def main():
         result = load(
             identifier=args.instance,
             storage=args.storage,
+            db_user_name=args.db_user,
+            db_user_password=args.db_password,
         )
         return process_result(result)
     elif args.command == "close":


### PR DESCRIPTION
As discussed with @bpenteado it works well for admin users, but not for the others as RLS policies on account_instance table prevent them to update the db_user_id field. 

@falexwolf could you try locally and validate the UX?

I will add tests once RLS problems are solved and UX will be validated.