### PR TITLE
♻️ Refactor optional cloud sqlite locking and unlocking

### DIFF
--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -229,7 +229,7 @@ def load_from_isettings(
         # during init both user and storage need to be registered
         register_user_and_storage(isettings, settings.user)
         write_bionty_sources(isettings)
-        isettings._update_cloud_sqlite_file()
+        isettings._update_cloud_sqlite_file(unlock_cloud_sqlite=False)
     else:
         # when loading, django is already set up
         # only register user if the instance is loaded

--- a/lamindb_setup/_load_instance.py
+++ b/lamindb_setup/_load_instance.py
@@ -103,7 +103,9 @@ def load(
         isettings._persist()  # this is to test the settings
         return None
     silence_loggers()
-    check, msg = isettings._load_db()  # this also updates local SQLite
+    check, msg = isettings._load_db(
+        do_not_lock_for_laminapp_admin=True
+    )  # this also updates local SQLite
     if not check:
         local_db = isettings._is_cloud_sqlite and isettings._sqlite_file_local.exists()
         if local_db:

--- a/lamindb_setup/dev/_settings_instance.py
+++ b/lamindb_setup/dev/_settings_instance.py
@@ -252,10 +252,9 @@ class InstanceSettings:
         # lock in all cases except if do_not_lock_for_laminapp_admin is True and
         # user is `laminapp-admin`
         # value doesn't matter if not a cloud sqlite instance
-        lock_cloud_sqlite = (
-            self._is_cloud_sqlite
-            and not do_not_lock_for_laminapp_admin
-            and settings.user.handle == "laminapp-admin"
+        lock_cloud_sqlite = self._is_cloud_sqlite and (
+            not do_not_lock_for_laminapp_admin
+            or settings.user.handle != "laminapp-admin"
         )
         # we need the local sqlite to setup django
         self._update_local_sqlite_file(lock_cloud_sqlite=lock_cloud_sqlite)


### PR DESCRIPTION
Make `_update_local_sqlite_file` and `_update_cloud_sqlite_file` consistent for optional locking and unlocking, avoid unneeded unlockin on instance init.