### PR TITLE
🐛 Do not unlock cloud sqlite instance on migrate deploy

### DIFF
--- a/lamindb_setup/dev/django.py
+++ b/lamindb_setup/dev/django.py
@@ -160,7 +160,7 @@ def setup_django(
         # only update if called from lamin migrate deploy
         # if called from load_schema(..., init=True)
         # no need to update the remote sqlite
-        isettings._update_cloud_sqlite_file()
+        isettings._update_cloud_sqlite_file(unlock_cloud_sqlite=False)
     else:
         if init:
             # create migrations


### PR DESCRIPTION
Now the instance is unlocked on `lamin migrate deploy`, logically it should not happen.