### PR TITLE
🐛 Use shutil.move to move the sqlite file when changing cache folder

### DIFF
--- a/lamindb_setup/_cache.py
+++ b/lamindb_setup/_cache.py
@@ -28,6 +28,4 @@ def set_cache_dir(cache_dir: str):
 
     settings.storage.cache_dir = cache_dir
     cache_str = settings.storage.cache_dir.as_posix()  # type: ignore
-    logger.success(
-        f"The cache directory of the current instance was set to {cache_str}."
-    )
+    logger.success(f"The cache directory was set to {cache_str}.")

--- a/lamindb_setup/dev/_settings_storage.py
+++ b/lamindb_setup/dev/_settings_storage.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from lamin_utils import logger
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -239,7 +240,7 @@ class StorageSettings:
                 dst_sqlite_file.parent.mkdir(parents=True, exist_ok=True)
                 if dst_sqlite_file.exists():
                     dst_sqlite_file.unlink()
-                src_sqlite_file.rename(dst_sqlite_file)
+                shutil.move(src_sqlite_file, dst_sqlite_file)
             save_system_storage_settings(self._cache_dir, self._storage_settings_file)
         except Exception as e:
             self._cache_dir = save_cache_dir


### PR DESCRIPTION
Fixes moving between devices