### PR TITLE
🐛 Fix for _exclusion rmdir

### DIFF
--- a/docs/hub-prod/test-sqlite-lock.ipynb
+++ b/docs/hub-prod/test-sqlite-lock.ipynb
@@ -49,6 +49,9 @@
    "outputs": [],
    "source": [
     "exclusion = root / \".lamindb/_exclusion/\"\n",
+    "# if cache is present, then .exists() for intermediate keys return False\n",
+    "# bug in s3fs\n",
+    "exclusion.fs.invalidate_cache()\n",
     "if exclusion.exists():\n",
     "    exclusion.rmdir()"
    ]
@@ -266,7 +269,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,

--- a/lamindb_setup/_delete.py
+++ b/lamindb_setup/_delete.py
@@ -22,7 +22,9 @@ def delete_by_isettings(isettings: InstanceSettings) -> None:
         try:
             if isettings._sqlite_file.exists():
                 isettings._sqlite_file.unlink()
-            exclusion_dir = isettings.storage.root / ".lamindb/_exclusion"
+            exclusion_dir = (
+                isettings.storage.root / f".lamindb/_exclusion/{isettings.id.hex}"
+            )
             if exclusion_dir.exists():
                 exclusion_dir.rmdir()
         except PermissionError:


### PR DESCRIPTION
if cache actually exists, then existence checks for intermediate keys fail