### PR TITLE
🔊 Do not show traceback for basic login errors

### DIFF
--- a/docs/hub-prod/test-insufficient-user-info.ipynb
+++ b/docs/hub-prod/test-insufficient-user-info.ipynb
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with pytest.raises(RuntimeError):\n",
+    "with pytest.raises(SystemExit):\n",
     "    ln_setup.login(\"testuser1\", password=\"dummy\")"
    ]
   },
@@ -120,7 +120,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with pytest.raises(RuntimeError):\n",
+    "with pytest.raises(SystemExit):\n",
     "    ln_setup.login(\"testuser1@lamin.ai\")"
    ]
   },

--- a/lamindb_setup/_setup_user.py
+++ b/lamindb_setup/_setup_user.py
@@ -28,8 +28,8 @@ def load_user(email: str | None = None, handle: str | None = None) -> str | None
     else:
         user_settings = load_or_create_user_settings()
         if email is None:
-            raise RuntimeError(
-                "Use your email for your first login in a compute environment. "
+            raise SystemExit(
+                "✗ Use your email for your first login in a compute environment. "
                 "After that, you can use your handle."
             )
         user_settings.email = email
@@ -76,11 +76,11 @@ def login(
         user_settings.password = key
 
     if user_settings.email is None:
-        raise RuntimeError("No stored user email, please call: lamin login {user}")
+        raise SystemExit("✗ No stored user email, please call: lamin login {user}")
 
     if user_settings.password is None:
-        raise RuntimeError(
-            "No stored API key, please call: lamin login <your-email> --key <API-key>"
+        raise SystemExit(
+            "✗ No stored API key, please call: lamin login <your-email> --key <API-key>"
         )
 
     from .core._hub_core import sign_in_hub


### PR DESCRIPTION
Several old `RuntimeError` instances are now `SystemExit` and have an error emoji.

Now:
```
% lamin login alex
✗ Use your email for your first login in a compute environment. After that, you can use your handle.
```

Previously:
```
% lamin login alex
❗ using anonymous user (to identify, call: lamin login)
Traceback (most recent call last):
  File "/Users/falexwolf/miniconda3/envs/py310/bin/lamin", line 8, in <module>
    sys.exit(main())
  File "/Users/falexwolf/miniconda3/envs/py310/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/falexwolf/miniconda3/envs/py310/lib/python3.10/site-packages/rich_click/rich_command.py", line 126, in main
    rv = self.invoke(ctx)
  File "/Users/falexwolf/miniconda3/envs/py310/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/falexwolf/miniconda3/envs/py310/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/falexwolf/miniconda3/envs/py310/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/falexwolf/repos/laminhub/rest-hub/sub/lamindb/sub/lamin-cli/lamin_cli/__main__.py", line 116, in login
    return login(user, key=key)
  File "/Users/falexwolf/repos/laminhub/rest-hub/sub/lamindb/sub/lamindb-setup/lamindb_setup/_setup_user.py", line 63, in login
    load_user(email, handle)
  File "/Users/falexwolf/repos/laminhub/rest-hub/sub/lamindb/sub/lamindb-setup/lamindb_setup/_setup_user.py", line 31, in load_user
    raise RuntimeError(
RuntimeError: Use your email for your first login in a compute environment. After that, you can use your handle.
```