### PR TITLE
♻️ Overhaul `init` for more convenient use in laminhub

### DIFF
--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -235,9 +235,9 @@ def connect(
                 return "instance-not-found"
         if isinstance(isettings, str):
             return isettings
-        # after we checked that isettings is not a string
-        # to lock passed user in isettings._load_db()
-        # has no effect if None or if not cloud sqlite
+        # at this point we have checked already that isettings is not a string
+        # _user is passed to lock cloud sqite for this user in isettings._load_db()
+        # has no effect if _user is None or if not cloud sqlite instance
         isettings._locker_user = _user
         if storage is not None:
             update_isettings_with_storage(isettings, storage)

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -27,6 +27,7 @@ from .core.cloud_sqlite_locker import unlock_cloud_sqlite_upon_exception
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from .core._settings_user import UserSettings
     from .core.types import UPathStr
 
 # this is for testing purposes only
@@ -197,10 +198,17 @@ def connect(
     """
     isettings: InstanceSettings = None  # type: ignore
 
-    access_token = kwargs.get("access_token", None)
-    _write_settings = kwargs.get("_write_settings", True)
-    _raise_not_found_error = kwargs.get("_raise_not_found_error", True)
-    _test = kwargs.get("_test", False)
+    _write_settings: bool = kwargs.get("_write_settings", True)
+    _raise_not_found_error: bool = kwargs.get("_raise_not_found_error", True)
+    _test: bool = kwargs.get("_test", False)
+
+    access_token: str | None = None
+    _user: UserSettings | None = kwargs.get("_user", None)
+    if _user is None:
+        user = settings.user
+    else:
+        user = _user
+        access_token = user.access_token
 
     try:
         owner, name = get_owner_name_from_identifier(slug)
@@ -272,7 +280,7 @@ def connect(
         #     # raised by django when the access is denied
         #     except ProgrammingError:
         #         pass
-        load_from_isettings(isettings, write_settings=_write_settings)
+        load_from_isettings(isettings, user=user, write_settings=_write_settings)
     except Exception as e:
         if isettings is not None:
             if _write_settings:

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -115,6 +115,7 @@ def _connect_instance(
     *,
     db: str | None = None,
     raise_permission_error: bool = True,
+    access_token: str | None = None,
 ) -> InstanceSettings:
     settings_file = instance_settings_file(name, owner)
     make_hub_request = True
@@ -128,9 +129,13 @@ def _connect_instance(
         # do not call hub if the user is anonymous
         if owner != "anonymous":
             if settings.user.handle in {"Koncopd", "sunnyosun", "falexwolf"}:
-                hub_result = load_instance_from_hub_edge(owner=owner, name=name)
+                hub_result = load_instance_from_hub_edge(
+                    owner=owner, name=name, access_token=access_token
+                )
             else:
-                hub_result = load_instance_from_hub(owner=owner, name=name)
+                hub_result = load_instance_from_hub(
+                    owner=owner, name=name, access_token=access_token
+                )
         else:
             hub_result = "anonymous-user"
         # if hub_result is not a string, it means it made a request
@@ -192,7 +197,7 @@ def connect(
     """
     isettings: InstanceSettings = None  # type: ignore
 
-    kwargs.get("access_token", None)
+    access_token = kwargs.get("access_token", None)
     _raise_not_found_error = kwargs.get("_raise_not_found_error", True)
     _test = kwargs.get("_test", False)
 
@@ -212,7 +217,7 @@ def connect(
             close_instance(mute=True)
 
         try:
-            isettings = _connect_instance(owner, name, db=db)
+            isettings = _connect_instance(owner, name, db=db, access_token=access_token)
         except InstanceNotFoundError as e:
             if _raise_not_found_error:
                 raise e

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -180,12 +180,7 @@ def _connect_instance(
 
 @unlock_cloud_sqlite_upon_exception(ignore_prev_locker=True)
 def connect(
-    slug: str,
-    *,
-    db: str | None = None,
-    storage: UPathStr | None = None,
-    _raise_not_found_error: bool = True,
-    _test: bool = False,
+    slug: str, *, db: str | None = None, storage: UPathStr | None = None, **kwargs
 ) -> str | tuple | None:
     """Connect to instance.
 
@@ -196,6 +191,11 @@ def connect(
         storage: Load the instance with an updated default storage.
     """
     isettings: InstanceSettings = None  # type: ignore
+
+    kwargs.get("access_token", None)
+    _raise_not_found_error = kwargs.get("_raise_not_found_error", True)
+    _test = kwargs.get("_test", False)
+
     try:
         owner, name = get_owner_name_from_identifier(slug)
 

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -293,11 +293,15 @@ def connect(
             settings_dir / f"no_lnschema_bionty-{isettings.slug.replace('/', '')}"
         )
         if not no_lnschema_bionty_file.exists():
-            migrate_lnschema_bionty(isettings, no_lnschema_bionty_file)
+            migrate_lnschema_bionty(
+                isettings, no_lnschema_bionty_file, write_file=_write_settings
+            )
     return None
 
 
-def migrate_lnschema_bionty(isettings: InstanceSettings, no_lnschema_bionty_file: Path):
+def migrate_lnschema_bionty(
+    isettings: InstanceSettings, no_lnschema_bionty_file: Path, write_file: bool = True
+):
     """Migrate lnschema_bionty tables to bionty tables if bionty_source doesn't exist.
 
     :param db_uri: str, database URI (e.g., 'sqlite:///path/to/db.sqlite' or 'postgresql://user:password@host:port/dbname')
@@ -350,7 +354,8 @@ def migrate_lnschema_bionty(isettings: InstanceSettings, no_lnschema_bionty_file
             ]
 
         if migrated:
-            no_lnschema_bionty_file.touch(exist_ok=True)
+            if write_file:
+                no_lnschema_bionty_file.touch(exist_ok=True)
         else:
             try:
                 # rename tables only if bionty_source doesn't exist and there are tables to rename
@@ -372,8 +377,8 @@ def migrate_lnschema_bionty(isettings: InstanceSettings, no_lnschema_bionty_file
                 logger.warning(
                     "Please uninstall lnschema-bionty via `pip uninstall lnschema-bionty`!"
                 )
-
-                no_lnschema_bionty_file.touch(exist_ok=True)
+                if write_file:
+                    no_lnschema_bionty_file.touch(exist_ok=True)
             except Exception:
                 # read-only users can't rename tables
                 pass

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -241,7 +241,7 @@ def connect(
         isettings._locker_user = _user
         if storage is not None:
             update_isettings_with_storage(isettings, storage)
-        isettings._persist(write=_write_settings)
+        isettings._persist(write_to_disk=_write_settings)
         if _test:
             return None
         silence_loggers()

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -244,9 +244,11 @@ def init(
     # contains access_token
     _user: UserSettings | None = kwargs.get("_user", None)
     if _user is None:
-        user_handle, user__uuid = settings.user.handle, settings.user._uuid.hex  # type: ignore
+        user_handle = settings.user.handle
+        user__uuid = None if settings.user._uuid is None else settings.user._uuid.hex
     else:
-        user_handle, user__uuid = _user.handle, _user._uuid.hex  # type: ignore
+        user_handle = _user.handle
+        user__uuid = None if _user._uuid is None else _user._uuid.hex
         access_token = _user.access_token
 
     try:

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -213,7 +213,7 @@ def init(
     name: str | None = None,
     db: PostgresDsn | None = None,
     schema: str | None = None,
-    _test: bool = False,
+    **kwargs,
 ) -> None:
     """Create and load a LaminDB instance.
 
@@ -226,6 +226,10 @@ def init(
     """
     isettings = None
     ssettings = None
+
+    kwargs.get("access_token", None)
+    _test = kwargs.get("_test", False)
+
     try:
         silence_loggers()
         from ._check_setup import _check_instance_setup

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -167,6 +167,7 @@ def validate_init_args(
     db: PostgresDsn | None = None,
     schema: str | None = None,
     _test: bool = False,
+    _write_settings: bool = True,
     _user: UserSettings | None = None,
 ) -> tuple[
     str,
@@ -194,6 +195,7 @@ def validate_init_args(
         db=db,
         _raise_not_found_error=False,
         _test=_test,
+        _write_settings=_write_settings,
         _user=_user,
     )
     instance_state: Literal[
@@ -267,6 +269,7 @@ def init(
             db=db,
             schema=schema,
             _test=_test,
+            _write_settings=_write_settings,
             _user=_user,  # will get from settings.user if _user is None
         )
         if instance_state == "connected":

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -246,7 +246,7 @@ def init(
     # contains access_token
     _user: UserSettings | None = kwargs.get("_user", None)
     user_handle: str = settings.user.handle if _user is None else _user.handle
-    user__uuid: UUID = settings.user._uuid if _user is None else settings.user._uuid  # type: ignore
+    user__uuid: UUID = settings.user._uuid if _user is None else _user._uuid  # type: ignore
 
     try:
         silence_loggers()

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -166,6 +166,7 @@ def validate_init_args(
     db: PostgresDsn | None = None,
     schema: str | None = None,
     _test: bool = False,
+    access_token: str | None = None,
 ) -> tuple[
     str,
     UUID | None,
@@ -186,7 +187,13 @@ def validate_init_args(
     name_str = infer_instance_name(storage=storage, name=name, db=db)
     # test whether instance exists by trying to load it
     instance_slug = f"{settings.user.handle}/{name_str}"
-    response = connect(instance_slug, db=db, _raise_not_found_error=False, _test=_test)
+    response = connect(
+        instance_slug,
+        db=db,
+        _raise_not_found_error=False,
+        _test=_test,
+        access_token=access_token,
+    )
     instance_state: Literal[
         "connected",
         "instance-corrupted-or-deleted",
@@ -227,7 +234,7 @@ def init(
     isettings = None
     ssettings = None
 
-    kwargs.get("access_token", None)
+    access_token = kwargs.get("access_token", None)
     _test = kwargs.get("_test", False)
 
     try:
@@ -246,6 +253,7 @@ def init(
             db=db,
             schema=schema,
             _test=_test,
+            access_token=access_token,
         )
         if instance_state == "connected":
             settings.auto_connect = True  # we can also debate this switch here

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -303,7 +303,7 @@ def init(
             )
         validate_sqlite_state(isettings)
         # why call it here if it is also called in load_from_isettings?
-        isettings._persist(write=_write_settings)
+        isettings._persist(write_to_disk=_write_settings)
         if _test:
             return None
         isettings._init_db()
@@ -371,7 +371,7 @@ def load_from_isettings(
         if not isettings._get_settings_file().exists():
             register_user(user)
         load_bionty_sources(isettings)
-    isettings._persist(write=write_settings)
+    isettings._persist(write_to_disk=write_settings)
     reload_lamindb(isettings)
 
 

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -296,6 +296,8 @@ def init(
             db=db,
             schema=schema,
             uid=ssettings.uid,
+            # to lock passed user in isettings._cloud_sqlite_locker.lock()
+            _locker_user=_user,  # only has effect if cloud sqlite
         )
         register_on_hub = (
             isettings.is_remote and instance_state != "instance-corrupted-or-deleted"
@@ -314,10 +316,7 @@ def init(
             isettings, init=True, user=_user, write_settings=_write_settings
         )
         if _write_settings and isettings._is_cloud_sqlite:
-            from .core.cloud_sqlite_locker import get_locker
-
-            # lock passed user if _user is not None
-            get_locker(isettings, _user).lock()
+            isettings._cloud_sqlite_locker.lock()
             logger.warning(
                 "locked instance (to unlock and push changes to the cloud SQLite file,"
                 " call: lamin load --unload)"

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -245,13 +245,8 @@ def init(
     # use this user instead of settings.user
     # contains access_token
     _user: UserSettings | None = kwargs.get("_user", None)
-    if _user is None:
-        user_handle = settings.user.handle
-        user__uuid = None if settings.user._uuid is None else settings.user._uuid.hex
-    else:
-        user_handle = _user.handle
-        user__uuid = None if _user._uuid is None else _user._uuid.hex
-        access_token = _user.access_token
+    user_handle: str = settings.user.handle if _user is None else _user.handle
+    user__uuid: UUID = settings.user._uuid if _user is None else settings.user._uuid  # type: ignore
 
     try:
         silence_loggers()

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -241,12 +241,12 @@ def init(
     _write_settings: bool = kwargs.get("_write_settings", True)
     _test: bool = kwargs.get("_test", False)
 
-    access_token: str | None = None
     # use this user instead of settings.user
     # contains access_token
     _user: UserSettings | None = kwargs.get("_user", None)
     user_handle: str = settings.user.handle if _user is None else _user.handle
     user__uuid: UUID = settings.user._uuid if _user is None else _user._uuid  # type: ignore
+    access_token: str | None = None if _user is None else _user.access_token
 
     try:
         silence_loggers()

--- a/lamindb_setup/_schema_metadata.py
+++ b/lamindb_setup/_schema_metadata.py
@@ -33,8 +33,8 @@ if TYPE_CHECKING:
     from supabase import Client
 
 
-def update_schema_in_hub() -> tuple[bool, UUID, dict]:
-    return call_with_fallback_auth(_synchronize_schema)
+def update_schema_in_hub(access_token: str | None = None) -> tuple[bool, UUID, dict]:
+    return call_with_fallback_auth(_synchronize_schema, access_token=access_token)
 
 
 def _synchronize_schema(client: Client) -> tuple[bool, UUID, dict]:

--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -38,12 +38,9 @@ if TYPE_CHECKING:
     from ._settings_instance import InstanceSettings
 
 
-def delete_storage_record(
-    storage_uuid: UUID,
-) -> None:
+def delete_storage_record(storage_uuid: UUID, access_token: str | None = None) -> None:
     return call_with_fallback_auth(
-        _delete_storage_record,
-        storage_uuid=storage_uuid,
+        _delete_storage_record, storage_uuid=storage_uuid, access_token=access_token
     )
 
 
@@ -119,12 +116,14 @@ def _select_storage(
 def init_storage(
     ssettings: StorageSettings,
     auto_populate_instance: bool = True,
+    access_token: str | None = None,
 ) -> Literal["hub-record-retireved", "hub-record-created"]:
-    if settings.user.handle != "anonymous":
+    if settings.user.handle != "anonymous" or access_token is not None:
         return call_with_fallback_auth(
             _init_storage,
             ssettings=ssettings,
             auto_populate_instance=auto_populate_instance,
+            access_token=access_token,
         )
     else:
         storage_exists = call_with_fallback(
@@ -253,17 +252,16 @@ def _delete_instance(
     return None
 
 
-def delete_instance_record(
-    instance_id: UUID,
-) -> None:
+def delete_instance_record(instance_id: UUID, access_token: str | None = None) -> None:
     return call_with_fallback_auth(
-        _delete_instance_record,
-        instance_id=instance_id,
+        _delete_instance_record, instance_id=instance_id, access_token=access_token
     )
 
 
-def init_instance(isettings: InstanceSettings) -> None:
-    return call_with_fallback_auth(_init_instance, isettings=isettings)
+def init_instance(isettings: InstanceSettings, access_token: str | None = None) -> None:
+    return call_with_fallback_auth(
+        _init_instance, isettings=isettings, access_token=access_token
+    )
 
 
 def _init_instance(isettings: InstanceSettings, client: Client) -> None:

--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -312,11 +312,14 @@ def connect_instance(
     *,
     owner: str,  # account_handle
     name: str,  # instance_name
+    access_token: str | None = None,
 ) -> tuple[dict, dict] | str:
     from ._settings import settings
 
-    if settings.user.handle != "anonymous":
-        return call_with_fallback_auth(_connect_instance, owner=owner, name=name)
+    if settings.user.handle != "anonymous" or access_token is not None:
+        return call_with_fallback_auth(
+            _connect_instance, owner=owner, name=name, access_token=access_token
+        )
     else:
         return call_with_fallback(_connect_instance, owner=owner, name=name)
 
@@ -424,11 +427,14 @@ def connect_instance_new(
     *,
     owner: str,  # account_handle
     name: str,  # instance_name
+    access_token: str | None = None,
 ) -> tuple[dict, dict] | str:
     from ._settings import settings
 
-    if settings.user.handle != "anonymous":
-        return call_with_fallback_auth(_connect_instance_new, owner=owner, name=name)
+    if settings.user.handle != "anonymous" or access_token is not None:
+        return call_with_fallback_auth(
+            _connect_instance_new, owner=owner, name=name, access_token=access_token
+        )
     else:
         return call_with_fallback(_connect_instance_new, owner=owner, name=name)
 

--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -116,7 +116,7 @@ def _select_storage(
 def init_storage(
     ssettings: StorageSettings,
     auto_populate_instance: bool = True,
-    created_by: str | None = None,
+    created_by: UUID | None = None,
     access_token: str | None = None,
 ) -> Literal["hub-record-retireved", "hub-record-created"]:
     if settings.user.handle != "anonymous" or access_token is not None:
@@ -141,11 +141,11 @@ def _init_storage(
     client: Client,
     ssettings: StorageSettings,
     auto_populate_instance: bool,
-    created_by: str | None = None,
+    created_by: UUID | None = None,
 ) -> Literal["hub-record-retireved", "hub-record-created"]:
     from lamindb_setup import settings
 
-    created_by = settings.user._uuid.hex if created_by is None else created_by  # type: ignore
+    created_by = settings.user._uuid if created_by is None else created_by
     # storage roots are always stored without the trailing slash in the SQL
     # database
     root = ssettings.root_as_str
@@ -172,7 +172,7 @@ def _init_storage(
     fields = {
         "id": id.hex,
         "lnid": ssettings.uid,
-        "created_by": created_by,
+        "created_by": created_by.hex,  # type: ignore
         "root": root,
         "region": ssettings.region,
         "type": ssettings.type,
@@ -266,7 +266,7 @@ def delete_instance_record(instance_id: UUID, access_token: str | None = None) -
 
 def init_instance(
     isettings: InstanceSettings,
-    account_id: str | None = None,
+    account_id: UUID | None = None,
     access_token: str | None = None,
 ) -> None:
     return call_with_fallback_auth(
@@ -278,11 +278,11 @@ def init_instance(
 
 
 def _init_instance(
-    client: Client, isettings: InstanceSettings, account_id: str | None = None
+    client: Client, isettings: InstanceSettings, account_id: UUID | None = None
 ) -> None:
     from ._settings import settings
 
-    account_id = settings.user._uuid.hex if account_id is None else account_id  # type: ignore
+    account_id = settings.user._uuid if account_id is None else account_id
 
     try:
         lamindb_version = metadata.version("lamindb")
@@ -290,7 +290,7 @@ def _init_instance(
         lamindb_version = None
     fields = {
         "id": isettings._id.hex,
-        "account_id": account_id,
+        "account_id": account_id.hex,  # type: ignore
         "name": isettings.name,
         "lnid": isettings.uid,
         "schema_str": isettings._schema_str,

--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -431,8 +431,14 @@ class InstanceSettings:
     def _get_settings_file(self) -> Path:
         return instance_settings_file(self.name, self.owner)
 
-    def _persist(self, write: bool = True) -> None:
-        if write:
+    def _persist(self, write_to_disk: bool = True) -> None:
+        """Set these instance settings as the current instance.
+
+        Args:
+            write_to_disk: Save these instance settings to disk and
+                overwrite the current instance settings file.
+        """
+        if write_to_disk:
             assert self.name is not None
             filepath = self._get_settings_file()
             # persist under filepath for later reference

--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -283,7 +283,8 @@ class InstanceSettings:
         if self._is_cloud_sqlite:
             sqlite_file = self._sqlite_file
             logger.warning(
-                f"updating & unlocking cloud SQLite '{sqlite_file}' of instance"
+                f"updating{' & unlocking' if unlock_cloud_sqlite else ''} cloud SQLite "
+                f"'{sqlite_file}' of instance"
                 f" '{self.slug}'"
             )
             cache_file = self.storage.cloud_to_local_no_update(sqlite_file)

--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -424,16 +424,16 @@ class InstanceSettings:
     def _get_settings_file(self) -> Path:
         return instance_settings_file(self.name, self.owner)
 
-    def _persist(self) -> None:
-        assert self.name is not None
-
-        filepath = self._get_settings_file()
-        # persist under filepath for later reference
-        save_instance_settings(self, filepath)
-        # persist under current file for auto load
-        shutil.copy2(filepath, current_instance_settings_file())
-        # persist under settings class for same session reference
-        # need to import here to avoid circular import
+    def _persist(self, write: bool = True) -> None:
+        if write:
+            assert self.name is not None
+            filepath = self._get_settings_file()
+            # persist under filepath for later reference
+            save_instance_settings(self, filepath)
+            # persist under current file for auto load
+            shutil.copy2(filepath, current_instance_settings_file())
+            # persist under settings class for same session reference
+            # need to import here to avoid circular import
         from ._settings import settings
 
         settings._instance_settings = self

--- a/lamindb_setup/core/_settings_storage.py
+++ b/lamindb_setup/core/_settings_storage.py
@@ -83,6 +83,7 @@ def init_storage(
     register_hub: bool | None = None,
     prevent_register_hub: bool = False,
     init_instance: bool = False,
+    access_token: str | None = None,
 ) -> tuple[
     StorageSettings,
     Literal["hub-record-not-created", "hub-record-retireved", "hub-record-created"],
@@ -129,6 +130,7 @@ def init_storage(
         root=root_str,
         region=region,
         instance_id=instance_id,
+        access_token=access_token,
     )
     # this stores the result of init_storage_hub
     hub_record_status: Literal[
@@ -141,12 +143,15 @@ def init_storage(
             from ._hub_core import init_storage as init_storage_hub
 
             hub_record_status = init_storage_hub(
-                ssettings, auto_populate_instance=not init_instance
+                ssettings,
+                auto_populate_instance=not init_instance,
+                access_token=access_token,
             )
     # below comes last only if everything else was successful
     try:
         # (federated) credentials for AWS access are provisioned under-the-hood
         # discussion: https://laminlabs.slack.com/archives/C04FPE8V01W/p1719260587167489
+        # if access_token was passed in ssettings, it is used here
         mark_storage_root(ssettings.root, ssettings.uid)  # type: ignore
     except Exception:
         logger.important(
@@ -157,7 +162,7 @@ def init_storage(
         # and we don't want to delete an existing storage record here
         # only newly created
         if hub_record_status == "hub-record-created" and ssettings._uuid is not None:
-            delete_storage_record(ssettings._uuid)  # type: ignore
+            delete_storage_record(ssettings._uuid, access_token=access_token)  # type: ignore
         ssettings._instance_id = None
     return ssettings, hub_record_status
 

--- a/lamindb_setup/core/_settings_storage.py
+++ b/lamindb_setup/core/_settings_storage.py
@@ -83,7 +83,7 @@ def init_storage(
     register_hub: bool | None = None,
     prevent_register_hub: bool = False,
     init_instance: bool = False,
-    created_by: str | None = None,
+    created_by: UUID | None = None,
     access_token: str | None = None,
 ) -> tuple[
     StorageSettings,

--- a/lamindb_setup/core/_settings_storage.py
+++ b/lamindb_setup/core/_settings_storage.py
@@ -83,6 +83,7 @@ def init_storage(
     register_hub: bool | None = None,
     prevent_register_hub: bool = False,
     init_instance: bool = False,
+    created_by: str | None = None,
     access_token: str | None = None,
 ) -> tuple[
     StorageSettings,
@@ -145,6 +146,7 @@ def init_storage(
             hub_record_status = init_storage_hub(
                 ssettings,
                 auto_populate_instance=not init_instance,
+                created_by=created_by,
                 access_token=access_token,
             )
     # below comes last only if everything else was successful

--- a/lamindb_setup/core/cloud_sqlite_locker.py
+++ b/lamindb_setup/core/cloud_sqlite_locker.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
     from pathlib import Path
     from uuid import UUID
 
+    from ._settings_instance import InstanceSettings
+    from ._settings_user import UserSettings
+
 EXPIRATION_TIME = 24 * 60 * 60 * 7  # 7 days
 
 MAX_MSG_COUNTER = 100  # print the msg after this number of iterations
@@ -176,12 +179,14 @@ class Locker:
 _locker: Locker | None = None
 
 
-def get_locker(isettings) -> Locker:
+def get_locker(
+    isettings: InstanceSettings, usettings: UserSettings | None = None
+) -> Locker:
     from ._settings import settings
 
     global _locker
 
-    user_uid = settings.user.uid
+    user_uid = settings.user.uid if usettings is None else usettings.uid
     storage_root = isettings.storage.root
 
     if (

--- a/tests/hub-cloud/scripts/script-init-pass-user-no-writes.py
+++ b/tests/hub-cloud/scripts/script-init-pass-user-no-writes.py
@@ -1,5 +1,5 @@
 import lamindb_setup as ln_setup
-from lamindb_setup.core._settings_load import load_user_settings
+from lamindb_setup.core._settings_load import load_instance_settings, load_user_settings
 from lamindb_setup.core._settings_store import user_settings_file_handle
 
 ln_setup.logout()
@@ -18,3 +18,6 @@ ln_setup.init(
 assert ln_setup.settings.instance.name == "test-init-no-writes"
 assert ln_setup.settings.instance.owner == "testuser1"
 assert not ln_setup.settings.instance._get_settings_file().exists()
+# load current_instance.env
+current_instance = load_instance_settings()
+assert current_instance.name != "test-init-no-writes"

--- a/tests/hub-cloud/scripts/script-init-pass-user-no-writes.py
+++ b/tests/hub-cloud/scripts/script-init-pass-user-no-writes.py
@@ -24,6 +24,7 @@ ln_setup.init(
 assert ln_setup.settings.instance.name == "test-init-no-writes"
 assert ln_setup.settings.instance.owner == "testuser1"
 assert not ln_setup.settings.instance._get_settings_file().exists()
+assert ln_setup.settings.instance._cloud_sqlite_locker.user == testuser1.uid
 # check that there were no change in current_instance.env
 # here in CI tests current_instance.env is just not present at the time of execution
 assert current_instance_exists == current_instance_file.exists()

--- a/tests/hub-cloud/scripts/script-init-pass-user-no-writes.py
+++ b/tests/hub-cloud/scripts/script-init-pass-user-no-writes.py
@@ -1,0 +1,20 @@
+import lamindb_setup as ln_setup
+from lamindb_setup.core._settings_load import load_user_settings
+from lamindb_setup.core._settings_store import user_settings_file_handle
+
+ln_setup.logout()
+assert ln_setup.settings.user.handle == "anonymous"
+
+testuser1 = load_user_settings(user_settings_file_handle("testuser1"))
+assert testuser1.handle == "testuser1"
+
+ln_setup.init(
+    storage="create-s3",
+    name="test-init-no-writes",
+    _user=testuser1,
+    _write_settings=False,
+)
+
+assert ln_setup.settings.instance.name == "test-init-no-writes"
+assert ln_setup.settings.instance.owner == "testuser1"
+assert not ln_setup.settings.instance._get_settings_file().exists()

--- a/tests/hub-cloud/scripts/script-init-pass-user-no-writes.py
+++ b/tests/hub-cloud/scripts/script-init-pass-user-no-writes.py
@@ -1,9 +1,15 @@
 import lamindb_setup as ln_setup
 from lamindb_setup.core._settings_load import load_instance_settings, load_user_settings
-from lamindb_setup.core._settings_store import user_settings_file_handle
+from lamindb_setup.core._settings_store import (
+    current_instance_settings_file,
+    user_settings_file_handle,
+)
 
 ln_setup.logout()
 assert ln_setup.settings.user.handle == "anonymous"
+
+current_instance_file = current_instance_settings_file()
+current_instance_exists = current_instance_file.exists()
 
 testuser1 = load_user_settings(user_settings_file_handle("testuser1"))
 assert testuser1.handle == "testuser1"
@@ -18,6 +24,9 @@ ln_setup.init(
 assert ln_setup.settings.instance.name == "test-init-no-writes"
 assert ln_setup.settings.instance.owner == "testuser1"
 assert not ln_setup.settings.instance._get_settings_file().exists()
-# load current_instance.env
-current_instance = load_instance_settings()
-assert current_instance.name != "test-init-no-writes"
+# check that there were no change in current_instance.env
+# here in CI tests current_instance.env is just not present at the time of execution
+assert current_instance_exists == current_instance_file.exists()
+if current_instance_exists:
+    current_instance = load_instance_settings(current_instance_file)
+    assert current_instance.name != "test-init-no-writes"

--- a/tests/hub-cloud/test_init_pass_user_no_writes.py
+++ b/tests/hub-cloud/test_init_pass_user_no_writes.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 
 

--- a/tests/hub-cloud/test_init_pass_user_no_writes.py
+++ b/tests/hub-cloud/test_init_pass_user_no_writes.py
@@ -3,8 +3,10 @@ import subprocess
 
 
 def test_init_no_writes():
+    subprocess.run("lamin login testuser1", shell=True)
     subprocess.run("lamin delete testuser1/test-init-no-writes --force", shell=True)
 
+    # calls logout
     result = subprocess.run(
         "python ./tests/hub-cloud/scripts/script-init-pass-user-no-writes.py",
         shell=True,

--- a/tests/hub-cloud/test_init_pass_user_no_writes.py
+++ b/tests/hub-cloud/test_init_pass_user_no_writes.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+
+
+def test_init_no_writes():
+    subprocess.run("lamin delete testuser1/test-init-no-writes --force", shell=True)
+
+    result = subprocess.run(
+        "python ./tests/hub-cloud/scripts/script-init-pass-user-no-writes.py",
+        shell=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+    subprocess.run("lamin login testuser1", shell=True)
+    subprocess.run("lamin delete testuser1/test-init-no-writes --force", shell=True)


### PR DESCRIPTION
https://github.com/laminlabs/laminhub/issues/1271

This moves all internal utility arguments to `kwargs` in `lamindb_setup.connect`.
Adds 2 additional arguments: `_user` and `_write_settings`.

1. `_user` allows to pass user settings (with `access_token`) to `connect` and they are used instead of `lamindb_setup.settings.user`.
2. `_write_settings` when set to `False` forces `connect` not to write any settings env files. It is set to `True` by default for now.

I believe this addresses point 1-2 in the linked issue.