### PR TITLE
♻️ Simplify connect by eliminating db and storage arguments

### DIFF
--- a/docs/hub-cloud/02-connect-local-instance.ipynb
+++ b/docs/hub-cloud/02-connect-local-instance.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b43d09d5-26d3-440d-b334-9643ec5248e6",
    "metadata": {
@@ -20,12 +19,9 @@
    },
    "outputs": [],
    "source": [
-    "# here, we construct a case in which the storage location of the previous instance was moved\n",
     "!lamin load --unload\n",
     "!lamin delete --force mydata\n",
     "!lamin init --storage mydata\n",
-    "!rm -r ./mydata_new_loc\n",
-    "!mv mydata ./mydata_new_loc\n",
     "!lamin load --unload"
    ]
   },
@@ -40,7 +36,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1be836bb",
    "metadata": {},
@@ -49,24 +44,11 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a5c94e19",
    "metadata": {},
    "source": [
-    "If the user is the instance owner, load the instance by name:\n",
-    "```\n",
-    "ln_setup.connect(\"mydata\")\n",
-    "```"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "c878d40a",
-   "metadata": {},
-   "source": [
-    "You can also load with a new default storage location:"
+    "If the user is the instance owner, load the instance by name:"
    ]
   },
   {
@@ -76,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln_setup.connect(\"mydata\", storage=\"./mydata_new_loc\")"
+    "ln_setup.connect(\"mydata\")"
    ]
   },
   {
@@ -94,18 +76,16 @@
     "\n",
     "assert ln_setup.settings.instance.storage.type_is_cloud == False\n",
     "assert ln_setup.settings.instance.name == \"mydata\"\n",
-    "assert (\n",
-    "    ln_setup.settings.instance.storage.root.as_posix()\n",
-    "    == Path(\"./mydata_new_loc\").resolve().as_posix()\n",
-    ")\n",
+    "\n",
+    "root_path = Path(\"./mydata\").resolve()\n",
+    "assert ln_setup.settings.instance.storage.root == root_path\n",
     "assert (\n",
     "    ln_setup.settings.instance.db\n",
-    "    == f\"sqlite:///{Path('./mydata_new_loc').resolve().as_posix()}/{ln_setup.settings.instance._id.hex}.lndb\"\n",
+    "    == f\"sqlite:///{root_path.as_posix()}/{ln_setup.settings.instance._id.hex}.lndb\"\n",
     ")"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0986a5f3",
    "metadata": {},
@@ -129,7 +109,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e3701120",
    "metadata": {},
@@ -166,7 +145,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.9.17"
   },
   "vscode": {
    "interpreter": {

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -192,7 +192,7 @@ def validate_init_args(
     instance_slug = f"{owner_str}/{name_str}"
     response = connect(
         instance_slug,
-        db=db,
+        _db=db,
         _raise_not_found_error=False,
         _test=_test,
         _write_settings=_write_settings,

--- a/tests/hub-cloud/test_connect_instance.py
+++ b/tests/hub-cloud/test_connect_instance.py
@@ -105,6 +105,11 @@ def test_connect_after_private_public_switch():
 
 
 def test_connect_with_db_parameter():
+    # no more db parameter, it is _db now and is hidden in kwargs
+    # this also tests that only allowed kwargs can be used
+    with pytest.raises(TypeError):
+        ln_setup.connect("laminlabs/lamindata", db="some_db")
+
     if os.getenv("LAMIN_ENV") == "prod":
         # take a write-level access collaborator
         ln_setup.login("testuser1")

--- a/tests/hub-cloud/test_connect_instance.py
+++ b/tests/hub-cloud/test_connect_instance.py
@@ -113,7 +113,7 @@ def test_connect_with_db_parameter():
         assert "root" in ln_setup.settings.instance.db
         # test load from provided db argument
         db = "postgresql://testdbuser:testpwd@database2.cmyfs24wugc3.us-east-1.rds.amazonaws.com:5432/db1"
-        ln_setup.connect("laminlabs/lamindata", db=db, _test=True)
+        ln_setup.connect("laminlabs/lamindata", _db=db, _test=True)
         assert "testdbuser" in ln_setup.settings.instance.db
         # test ignore loading from cache because hub result has >read access
         ln_setup.connect("laminlabs/lamindata", _test=True)
@@ -125,7 +125,7 @@ def test_connect_with_db_parameter():
         ln_setup.connect("laminlabs/lamindata", _test=True)
         assert "root" in ln_setup.settings.instance.db
         # now pass the connection string
-        ln_setup.connect("laminlabs/lamindata", db=db, _test=True)
+        ln_setup.connect("laminlabs/lamindata", _db=db, _test=True)
         assert "testdbuser" in ln_setup.settings.instance.db
         # now the cache is used
         ln_setup.connect("laminlabs/lamindata", _test=True)
@@ -134,7 +134,7 @@ def test_connect_with_db_parameter():
         # test corrupted input
         db_corrupted = "postgresql://testuser:testpwd@wrongserver:5432/db1"
         with pytest.raises(ValueError) as error:
-            ln_setup.connect("laminlabs/lamindata", db=db_corrupted, _test=True)
+            ln_setup.connect("laminlabs/lamindata", _db=db_corrupted, _test=True)
         assert error.exconly().startswith(
             "ValueError: The local differs from the hub database information"
         )

--- a/tests/storage/test_storage_access.py
+++ b/tests/storage/test_storage_access.py
@@ -24,7 +24,7 @@ def test_connect_instance_with_private_storage_and_no_storage_access():
     # storage during connection
     ln_setup.connect(
         "laminlabs/test-instance-private-postgres",
-        db=os.environ["TEST_INSTANCE_PRIVATE_POSTGRES"],
+        _db=os.environ["TEST_INSTANCE_PRIVATE_POSTGRES"],
         _test=True,
     )
     # accessing storage in the instance should fail:


### PR DESCRIPTION
Closes https://github.com/laminlabs/lamindb-setup/issues/862
This eliminates `storage` completely and moves `db` to `kwargs` `_db`, because passing db string is still needed for internal use.