### PR TITLE
🚸 Do not error if a schema module of an instance isn't installed

### DIFF
--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -34,7 +34,7 @@ def get_schema_module_name(schema_name, raise_import_error: bool = True) -> str 
         module_spec = importlib.util.find_spec(name)
         if module_spec is not None:
             return name
-    message = f"Schema module '{schema_name}' is not installed → no access to its registries (resolve via `pip install {schema_name}`)"
+    message = f"Schema module '{schema_name}' is not installed → no access to its labels & registries (resolve via `pip install {schema_name}`)"
     if raise_import_error:
         raise ImportError(message)
     logger.warning(message.lower())

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from .core.types import UPathStr
 
 
-def get_schema_module_name(schema_name) -> str | None:
+def get_schema_module_name(schema_name, raise_import_error: bool = True) -> str | None:
     import importlib.util
 
     name_attempts = [f"lnschema_{schema_name.replace('-', '_')}", schema_name]
@@ -34,10 +34,10 @@ def get_schema_module_name(schema_name) -> str | None:
         module_spec = importlib.util.find_spec(name)
         if module_spec is not None:
             return name
-    logger.warning(
-        f"schema module '{schema_name}' is not installed → no access to its registries"
-        f" (resolve via `pip install {schema_name}`)"
-    )
+    message = f"Schema module '{schema_name}' is not installed → no access to its registries (resolve via `pip install {schema_name}`)"
+    if raise_import_error:
+        raise ImportError(message)
+    logger.warning(message.lower())
     return None
 
 

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from .core.types import UPathStr
 
 
-def get_schema_module_name(schema_name) -> str:
+def get_schema_module_name(schema_name) -> str | None:
     import importlib.util
 
     name_attempts = [f"lnschema_{schema_name.replace('-', '_')}", schema_name]
@@ -34,9 +34,11 @@ def get_schema_module_name(schema_name) -> str:
         module_spec = importlib.util.find_spec(name)
         if module_spec is not None:
             return name
-    raise ImportError(
-        f"Python package for '{schema_name}' is not installed.\nIf your package is on PyPI, run `pip install {schema_name}`"
+    logger.warning(
+        f"schema module '{schema_name}' is not installed → no access to its registries"
+        f" (resolve via `pip install {schema_name}`)"
     )
+    return None
 
 
 def register_storage_in_instance(ssettings: StorageSettings):

--- a/lamindb_setup/core/django.py
+++ b/lamindb_setup/core/django.py
@@ -55,7 +55,11 @@ def setup_django(
         from .._init_instance import get_schema_module_name
 
         schema_names = ["core"] + list(isettings.schema)
-        installed_apps = [get_schema_module_name(n) for n in schema_names]
+        installed_apps = [
+            package_name
+            for n in schema_names
+            if (package_name := get_schema_module_name(n)) is not None
+        ]
         if view_schema:
             installed_apps = installed_apps[::-1]  # to fix how apps appear
             installed_apps += ["schema_graph", "django.contrib.staticfiles"]

--- a/lamindb_setup/core/django.py
+++ b/lamindb_setup/core/django.py
@@ -58,7 +58,8 @@ def setup_django(
         installed_apps = [
             package_name
             for n in schema_names
-            if (package_name := get_schema_module_name(n)) is not None
+            if (package_name := get_schema_module_name(n, raise_import_error=False))
+            is not None
         ]
         if view_schema:
             installed_apps = installed_apps[::-1]  # to fix how apps appear

--- a/lamindb_setup/core/django.py
+++ b/lamindb_setup/core/django.py
@@ -55,10 +55,15 @@ def setup_django(
         from .._init_instance import get_schema_module_name
 
         schema_names = ["core"] + list(isettings.schema)
+        raise_import_error = True if init else False
         installed_apps = [
             package_name
             for n in schema_names
-            if (package_name := get_schema_module_name(n, raise_import_error=False))
+            if (
+                package_name := get_schema_module_name(
+                    n, raise_import_error=raise_import_error
+                )
+            )
             is not None
         ]
         if view_schema:

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ def lint(session: nox.Session) -> None:
     ["hub-local", "hub-prod", "hub-cloud", "storage", "docs"],
 )
 def install(session: nox.Session, group: str) -> None:
-    no_deps_packages = "git+https://github.com/laminlabs/lnschema-core git+https://github.com/laminlabs/wetlab git+https://github.com/laminlabs/lamin-cli git+https://github.com/laminlabs/findrefs"
+    no_deps_packages = "git+https://github.com/laminlabs/lnschema-core git+https://github.com/laminlabs/wetlab git+https://github.com/laminlabs/lamin-cli"
     schema_deps = f"""uv pip install --system git+https://github.com/laminlabs/bionty git+https://github.com/laminlabs/lamindb
 uv pip install --system --no-deps {no_deps_packages}
 """


### PR DESCRIPTION
If you don't have a schema module installed, you'll not see the metadata from its registries.

For example, in an environment that lacks `findrefs`:
```python
>>> import lamindb as ln
! schema module 'findrefs' is not installed → no access to its registries (resolve via `pip install findrefs`)
→ connected lamindb: laminlabs/lamin-dev
>>> artifact = ln.Artifact.get("iw9RRhFApeJVHC1L0001")
>>> artifact.describe()
Artifact(uid='iw9RRhFApeJVHC1L0001', version='1.0', is_latest=True, description='my RNA-seq', suffix='.parquet', type='dataset', size=4091, hash='pYYPTWIvnIZ83a9_0WLNYg', _hash_type='md5', _accessor='DataFrame', visibility=1, _key_is_virtual=True, created_at=2024-09-02 14:15:10 UTC)
  Provenance
    .storage = 's3://lamin-eu-central-1/9fm7UN13'
    .transform = 'Introduction'
    .run = '2024-09-03 19:23:15 UTC'
    .created_by = 'falexwolf'
```
In an environment that has `findrefs`, you'll see the annotation with the reference:
```python
>>> import lamindb as ln
→ connected lamindb: laminlabs/lamin-dev
>>> artifact = ln.Artifact.get("iw9RRhFApeJVHC1L0001")
>>> artifact.describe()
Artifact(uid='iw9RRhFApeJVHC1L0001', version='1.0', is_latest=True, description='my RNA-seq', suffix='.parquet', type='dataset', size=4091, hash='pYYPTWIvnIZ83a9_0WLNYg', _hash_type='md5', _accessor='DataFrame', visibility=1, _key_is_virtual=True, created_at=2024-09-02 14:15:10 UTC)
  Provenance
    .storage = 's3://lamin-eu-central-1/9fm7UN13'
    .transform = 'Introduction'
    .run = '2024-09-03 19:23:15 UTC'
    .created_by = 'falexwolf'
  Labels
    .references = 'My awesome paper'
```
