### PR TITLE
✨ Set anon for specified public s3 buckets if aws credentials fail

### DIFF
--- a/lamindb_setup/core/_aws_credentials.py
+++ b/lamindb_setup/core/_aws_credentials.py
@@ -147,7 +147,7 @@ class AWSCredentialsManager:
                         root = "/".join(path.path.rstrip("/").split("/")[:2])
                     else:
                         # write the bucket for everything else
-                        root = path._url.netloc
+                        root = path.drive
                     root = "s3://" + root
                 self._set_cached_credentials(_keep_trailing_slash(root), credentials)
 

--- a/lamindb_setup/core/_aws_credentials.py
+++ b/lamindb_setup/core/_aws_credentials.py
@@ -15,9 +15,7 @@ HOSTED_REGIONS = [
 ]
 lamin_env = os.getenv("LAMIN_ENV")
 if lamin_env is None or lamin_env == "prod":
-    hosted_buckets_list = [f"s3://lamin-{region}" for region in HOSTED_REGIONS]
-    hosted_buckets_list.append("s3://scverse-spatial-eu-central-1")
-    HOSTED_BUCKETS = tuple(hosted_buckets_list)
+    HOSTED_BUCKETS = tuple([f"s3://lamin-{region}" for region in HOSTED_REGIONS])
 else:
     HOSTED_BUCKETS = ("s3://lamin-hosted-test",)  # type: ignore
 

--- a/tests/hub-prod/test_aws_credentials_manager.py
+++ b/tests/hub-prod/test_aws_credentials_manager.py
@@ -2,7 +2,7 @@ from lamindb_setup.core._aws_credentials import get_aws_credentials_manager
 from lamindb_setup.core.upath import UPath
 
 
-def test_anon_piblic():
+def test_anon_public():
     aws_credentials_manager = get_aws_credentials_manager()
     assert aws_credentials_manager.anon_public is not None
     assert not aws_credentials_manager.anon_public

--- a/tests/hub-prod/test_aws_credentials_manager.py
+++ b/tests/hub-prod/test_aws_credentials_manager.py
@@ -1,0 +1,13 @@
+from lamindb_setup.core._aws_credentials import get_aws_credentials_manager
+from lamindb_setup.core.upath import UPath
+
+
+def test_anon_piblic():
+    aws_credentials_manager = get_aws_credentials_manager()
+    assert aws_credentials_manager.anon_public is not None
+    assert not aws_credentials_manager.anon_public
+
+    aws_credentials_manager.anon_public = True
+
+    path = aws_credentials_manager.enrich_path(UPath("s3://cellxgene-data-public"))
+    assert path.storage_options["anon"]

--- a/tests/hub-prod/test_aws_credentials_manager.py
+++ b/tests/hub-prod/test_aws_credentials_manager.py
@@ -2,12 +2,19 @@ from lamindb_setup.core._aws_credentials import get_aws_credentials_manager
 from lamindb_setup.core.upath import UPath
 
 
-def test_anon_public():
+def test_aws_credentials_manager():
     aws_credentials_manager = get_aws_credentials_manager()
     assert aws_credentials_manager.anon_public is not None
     assert not aws_credentials_manager.anon_public
 
     aws_credentials_manager.anon_public = True
 
-    path = aws_credentials_manager.enrich_path(UPath("s3://cellxgene-data-public"))
+    path = aws_credentials_manager.enrich_path(
+        UPath("s3://cellxgene-data-public/folder")
+    )
     assert path.storage_options["anon"]
+    assert "s3://cellxgene-data-public/" in aws_credentials_manager._credentials_cache
+
+    path = aws_credentials_manager.enrich_path(UPath("s3://lamin-eu-west-2/folder"))
+    assert not path.storage_options["anon"]
+    assert "s3://lamin-eu-west-2/folder/" in aws_credentials_manager._credentials_cache


### PR DESCRIPTION
Re https://github.com/laminlabs/pfizer-lamin-usage/issues/54 https://github.com/laminlabs/pfizer-lamin-usage/issues/55
This checks if aws credentials are able to resolve `head_bucket` on a test bucket (lamindata) and if not then sets anon=True for a specified list of public buckets.
This checks with `head_bucket` only once on init.