### PR TITLE
💚 Fix CI build

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -47,7 +47,7 @@ uv pip install --system --no-deps {no_deps_packages}
     elif group == "hub-local":
         cmds = schema_deps.strip()
     # current package
-    cmds += """\nuv pip install --system -e '.[aws,dev]' lamin-cli"""
+    cmds += """\nuv pip install --system -e '.[aws,dev]'"""
 
     # above downgrades django, I don't understand why, try this
     if group == "hub-local":


### PR DESCRIPTION
Sometimes, during releases, it reinstalls `lamin-cli` to older versions for some reason.