### PR TITLE
🥅 Check instance.modules when loading a lamindb schema module

### DIFF
--- a/docs/hub-cloud/01-init-local-instance.ipynb
+++ b/docs/hub-cloud/01-init-local-instance.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -107,7 +106,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.16"
   },
   "vscode": {
    "interpreter": {

--- a/docs/hub-cloud/02-connect-local-instance.ipynb
+++ b/docs/hub-cloud/02-connect-local-instance.ipynb
@@ -32,7 +32,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import lamindb_setup as ln_setup"
+    "import lamindb_setup as ln_setup\n",
+    "from lamindb_setup._check_setup import ModuleWasntConfigured\n",
+    "import pytest"
    ]
   },
   {
@@ -54,11 +56,54 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1106eff3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# bionty is not in the (schema) modules of mydata\n",
+    "# _check_instance_setup is called inside with from_module=None\n",
+    "# the branch where django is not setup yet\n",
+    "# as from_module=None it won't connect to an instance here\n",
+    "import bionty"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "b857dc27",
    "metadata": {},
    "outputs": [],
    "source": [
     "ln_setup.connect(\"mydata\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86a1cb7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# wetlab is not in the (schema) modules of mydata\n",
+    "with pytest.raises(ModuleWasntConfigured):\n",
+    "    # _check_instance_setup is called inside with from_module=None\n",
+    "    # the branch where django is setup\n",
+    "    import wetlab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "799740b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# wetlab is not in the (schema) modules of mydata\n",
+    "with pytest.raises(ModuleWasntConfigured):\n",
+    "    # _check_instance_setup is called inside with from_module=\"bionty\"\n",
+    "    # the branch where django is setup\n",
+    "    # in __getattr__ in __init__.py\n",
+    "    bionty.CellType"
    ]
   },
   {
@@ -122,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.10.16"
   },
   "vscode": {
    "interpreter": {

--- a/docs/hub-cloud/02-connect-local-instance.ipynb
+++ b/docs/hub-cloud/02-connect-local-instance.ipynb
@@ -74,7 +74,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln_setup.connect(\"mydata\")"
+    "ln_setup.connect(\n",
+    "    \"mydata\", _reload_lamindb=False\n",
+    ")  # also test passing _reload_lamindb explicitly"
    ]
   },
   {

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -80,7 +80,10 @@ def _get_current_instance_settings() -> InstanceSettings | None:
 def _check_module_in_instance_modules(
     module: str, isettings: InstanceSettings | None = None
 ) -> None:
-    not_in_instance_msg = f"'{module}' is missing from this instance."
+    not_in_instance_msg = (
+        f"'{module}' is missing from this instance. "
+        "Please go to your instance settings page and add it under 'schema modules'."
+    )
 
     if isettings is not None:
         if module not in isettings.modules:

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -90,7 +90,7 @@ def _module_name() -> str | None:
     if len(stack) < 3:
         return None
     module = inspect.getmodule(stack[2][0])
-    return module.__name__ if module is not None else None
+    return module.__name__.partition(".")[0] if module is not None else None
 
 
 # we make this a private function because in all the places it's used,
@@ -104,9 +104,12 @@ def _check_instance_setup(from_module: str | None = None) -> bool:
                 _check_in_modules(from_module)
                 il.reload(il.import_module(from_module))
         else:
-            from_module = _module_name()
-            if from_module != "lamindb":
-                _check_in_modules(from_module)  # type: ignore
+            infer_module = _module_name()
+            if infer_module is not None and infer_module not in {
+                "lamindb",
+                "lamindb_setup",
+            }:
+                _check_in_modules(infer_module)
         return True
     silence_loggers()
     if os.environ.get("LAMINDB_MULTI_INSTANCE") == "true":

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -39,7 +39,7 @@ class ModuleWasntConfigured(SystemExit):
 
 
 # decorator to disable auto-connect when importing a module such as lamindb
-def _loading(func: Callable):
+def disable_auto_connect(func: Callable):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         global IS_LOADING

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -34,7 +34,7 @@ CURRENT_ISETTINGS: InstanceSettings | None = None
 IS_LOADING: bool = False
 
 
-class ModuleWasntConfigured(RuntimeError):
+class ModuleWasntConfigured(SystemExit):
     pass
 
 

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -74,8 +74,11 @@ def _get_current_instance_settings() -> InstanceSettings | None:
 def _check_in_modules(module: str, isettings: InstanceSettings | None = None) -> None:
     not_in_instance_msg = f"'{module}' is missing from this instance."
 
-    if isettings is not None and module not in isettings.modules:
-        raise RuntimeError(not_in_instance_msg)
+    if isettings is not None:
+        if module not in isettings.modules:
+            raise RuntimeError(not_in_instance_msg)
+        else:
+            return
 
     from django.apps import apps
 

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -123,6 +123,7 @@ def _check_instance_setup(from_module: str | None = None) -> bool:
             if infer_module is not None and infer_module not in {
                 "lamindb",
                 "lamindb_setup",
+                "lamin_cli",
             }:
                 _check_module_in_instance_modules(infer_module)
         return True

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -311,7 +311,8 @@ def connect(instance: str | None = None, **kwargs) -> str | tuple | None:
         load_from_isettings(isettings, user=_user, write_settings=_write_settings)
         if _reload_lamindb:
             importlib.reload(importlib.import_module("lamindb"))
-        logger.important(f"connected lamindb: {isettings.slug}")
+        else:
+            logger.important(f"connected lamindb: {isettings.slug}")
     except Exception as e:
         if isettings is not None:
             if _write_settings:

--- a/lamindb_setup/_migrate.py
+++ b/lamindb_setup/_migrate.py
@@ -5,7 +5,7 @@ from django.db.migrations.loader import MigrationLoader
 from lamin_utils import logger
 from packaging import version
 
-from ._check_setup import _check_instance_setup, _loading
+from ._check_setup import _check_instance_setup, disable_auto_connect
 from .core._settings import settings
 from .core.django import setup_django
 
@@ -62,7 +62,7 @@ class migrate:
     """
 
     @classmethod
-    @_loading
+    @disable_auto_connect
     def create(cls) -> None:
         """Create a migration."""
         if _check_instance_setup():
@@ -70,7 +70,7 @@ class migrate:
         setup_django(settings.instance, create_migrations=True)
 
     @classmethod
-    @_loading
+    @disable_auto_connect
     def deploy(cls) -> None:
         """Deploy a migration."""
         from ._schema_metadata import update_schema_in_hub
@@ -115,7 +115,7 @@ class migrate:
             )
 
     @classmethod
-    @_loading
+    @disable_auto_connect
     def check(cls) -> bool:
         """Check whether Registry definitions are in sync with migrations."""
         from django.core.management import call_command
@@ -132,7 +132,7 @@ class migrate:
         return True
 
     @classmethod
-    @_loading
+    @disable_auto_connect
     def squash(
         cls, package_name, migration_nr, start_migration_nr: str | None = None
     ) -> None:
@@ -148,7 +148,7 @@ class migrate:
             call_command("squashmigrations", package_name, migration_nr)
 
     @classmethod
-    @_loading
+    @disable_auto_connect
     def show(cls) -> None:
         """Show migrations."""
         from django.core.management import call_command

--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -466,11 +466,11 @@ class InstanceSettings:
         settings._instance_settings = self
 
     def _init_db(self):
-        from lamindb_setup._check_setup import _loading
+        from lamindb_setup._check_setup import disable_auto_connect
 
         from .django import setup_django
 
-        _loading(setup_django)(self, init=True)
+        disable_auto_connect(setup_django)(self, init=True)
 
         from lamindb.models import Space
 
@@ -495,10 +495,10 @@ class InstanceSettings:
         # setting up django also performs a check for migrations & prints them
         # as warnings
         # this should fail, e.g., if the db is not reachable
-        from lamindb_setup._check_setup import _loading
+        from lamindb_setup._check_setup import disable_auto_connect
 
         from .django import setup_django
 
-        _loading(setup_django)(self)
+        disable_auto_connect(setup_django)(self)
 
         return True, ""


### PR DESCRIPTION
And raise `RuntimeError` if it is not there.