### PR TITLE
🚸 Accept `None` in `connect()` and improve migration dialogue

### DIFF
--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -381,7 +381,7 @@ def migrate_lnschema_core(
         else:
             try:
                 response = input(
-                    f"Do you want to migrate to lamindb 0.78 (integrate lnschema_core into lamindb)? (y/n) -- Will rename {tables_to_rename}"
+                    f"Do you want to migrate to lamindb 1.0 (integrate lnschema_core into lamindb)? (y/n) -- Will rename {tables_to_rename}"
                 )
                 if response != "y":
                     print("Aborted.")

--- a/lamindb_setup/_migrate.py
+++ b/lamindb_setup/_migrate.py
@@ -23,9 +23,9 @@ def check_whether_migrations_in_sync(db_version_str: str):
         return None
     installed_version = version.parse(installed_version_str)
     db_version = version.parse(db_version_str)
-    if (
-        installed_version.major < db_version.major
-        or installed_version.minor < db_version.minor
+    if installed_version.major < db_version.major or (
+        installed_version.major == db_version.major
+        and installed_version.minor < db_version.minor
     ):
         db_version_lower = f"{db_version.major}.{db_version.minor}"
         db_version_upper = f"{db_version.major}.{db_version.minor + 1}"
@@ -37,9 +37,9 @@ def check_whether_migrations_in_sync(db_version_str: str):
             "please update lamindb: pip install"
             f' "lamindb>={db_version_lower},<{db_version_upper}"'
         )
-    elif (
-        installed_version.major > db_version.major
-        or installed_version.minor > db_version.minor
+    elif installed_version.major > db_version.major or (
+        installed_version.major == db_version.major
+        and installed_version.minor > db_version.minor
     ):
         logger.warning(
             f"the database ({db_version_str}) is behind your installed lamindb package"

--- a/tests/hub-cloud/test_connect_instance.py
+++ b/tests/hub-cloud/test_connect_instance.py
@@ -12,7 +12,12 @@ from postgrest.exceptions import APIError
 
 
 def test_connect_pass_none():
-    ln_setup.connect(_test=True)
+    with pytest.raises(SystemExit) as err:
+        ln_setup.connect(_test=True)
+    assert (
+        err.exconly()
+        == "SystemExit: No instance was connected through the CLI, pass a value to `instance` or connect via the CLI."
+    )
 
 
 # do not call hub if the owner is set to anonymous

--- a/tests/hub-cloud/test_connect_instance.py
+++ b/tests/hub-cloud/test_connect_instance.py
@@ -10,12 +10,9 @@ from lamindb_setup.core._hub_crud import update_instance
 from laminhub_rest.core.instance.collaborator import InstanceCollaboratorHandler
 from postgrest.exceptions import APIError
 
-# @pytest.fixture
-# def create_remote_test_instance():
-#     ln_setup.login("testuser1")
-#     ln_setup.init(storage="s3://lamindb-ci/load_remote_instance", _test=True)
-#     yield
-#     ln_setup.delete("load_remote_instance", force=True)
+
+def test_connect_pass_none():
+    ln_setup.connect(_test=True)
 
 
 # do not call hub if the owner is set to anonymous


### PR DESCRIPTION
Addresses:

- https://github.com/laminlabs/lamindb-setup/issues/948

Also improves the migration dialogue when instance version and package version mismatch.