### PR TITLE
✨ Improve local storage not found warning message

### DIFF
--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -171,7 +171,8 @@ class InstanceSettings:
             return StorageSettings(record.root)
         elif not mute_warning:
             logger.warning(
-                f"none of the registered local storage locations were found in your environment: {local_records}"
+                "none of the registered local storage locations were found:\n    "
+                + "\n    ".join(r.root for r in all_local_records)
             )
             logger.important(
                 "please register a new local storage location via `ln.settings.storage_local = local_root_path` and re-load/connect the instance"


### PR DESCRIPTION
Fixes #954 

Before:

```
! none of the registered local storage locations were found in your environment: <QuerySet [Storage(uid='SOMEID', root='/data/path', type='local', instance_uid='SOMEID', created_by_id=6, space_id=1, created_at=2024-07-26 13:14:05 UTC), Storage(uid='SOMEID', root='/data/path2', type='local', instance_uid='SOMEID', created_by_id=4, space_id=1, created_at=2024-06-19 12:52:20 UTC),....THIS CONTINUES FOR A WHOLE PAGE SO THAT MY TERMINAL WAS COMPLETELY FLOODED
```

After:

```
lukas@lukas ~/c/lamindb-setup (main)> lamin connect customer/instance
! none of the registered local storage locations were found:
    /data/specific/path
    /data/specific/path2
    /data/specific/path3
    /data/specific/path4
    /data/specific/path5
    /data/specific/path6
→ please register a new local storage location via `ln.settings.storage_local = local_root_path` and re-load/connect the instance
```