### PR TITLE
⬆️ Bump django to >= 5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "description"]
 dependencies = [
     "lamin_utils>=0.3.3",
     # External dependencies
-    "django>=5,<5.2",
+    "django>=5.1,<5.2",
     "dj_database_url>=1.3.0,<3.0.0",
     "pydantic-settings",
     "appdirs<2.0.0",


### PR DESCRIPTION
Otherwise incompatible with passing `condition` to `django.db.models.CheckConstraint`.