### PR TITLE
🐛 Error if trying to register an instance without a storage in the hub

### DIFF
--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -284,6 +284,13 @@ def init(
             isettings.is_remote and instance_state != "instance-corrupted-or-deleted"
         )
         if register_on_hub:
+            # can't register the instance in the hub
+            # if storage is not in the hub
+            # raise the exception and initiate cleanups
+            if not isettings.storage.is_on_hub:
+                raise RuntimeError(
+                    "Unable to create the instance because failed to register the storage."
+                )
             init_instance_hub(
                 isettings, account_id=user__uuid, access_token=access_token
             )


### PR DESCRIPTION
Covers the cases when there is no write access to the cloud bucket etc.