### PR TITLE
🐛 Use pyjwt to decode access_token

### DIFF
--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -7,6 +7,7 @@ from importlib import metadata
 from typing import TYPE_CHECKING, Literal
 from uuid import UUID
 
+import jwt
 from lamin_utils import logger
 from postgrest.exceptions import APIError
 
@@ -548,7 +549,7 @@ def _sign_in_hub_api_key(api_key: str, client: Client):
     access_token = json.loads(response)["accessToken"]
     # probably need more info here to avoid additional queries
     # like handle, uid etc
-    account_id = client.auth._decode_jwt(access_token)["sub"]
+    account_id = jwt.decode(access_token, options={"verify_signature": False})["sub"]
     client.postgrest.auth(access_token)
     # normally public.account.id is equal to auth.user.id
     data = client.table("account").select("*").eq("id", account_id).execute().data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "botocore<2.0.0",
     "supabase>=2.8.1,<=2.11.0", # from 2.8.1 has correct bounds on gotrue
     "storage3!=0.11.2; python_version < '3.11'", # 0.11.2 breaks python 3.10 through usage of new types
+    "pyjwt<3.0.0", # needed to decode jwt for sign in with the new api key
     "psutil",
     "packaging"
 ]
@@ -42,7 +43,6 @@ erdiagram = [
 ]
 dev = [
     "line_profiler",
-    "pyjwt<3.0.0",
     "psycopg2-binary",
     "python-dotenv",
     "nox",


### PR DESCRIPTION
The new version of `gotrue` doesn't have `_decode_jwt` anymore.