### PR TITLE
🐛 Return an empty set not a dict for modules

### DIFF
--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -286,7 +286,7 @@ class InstanceSettings:
         The core schema contained in lamindb is not included in this set.
         """
         if self._schema_str is None:
-            return {}  # type: ignore
+            return set()
         else:
             return {module for module in self._schema_str.split(",") if module != ""}
 


### PR DESCRIPTION
Should have been fixed a long time ago. 😔 