### PR TITLE
✨ Expand user directory by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10" # run one job on 3.9
+          python-version: "3.10"
           cache: "pip"
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -35,7 +35,7 @@ jobs:
 
   # tests both on production and staging hub
   hub-cloud:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +43,7 @@ jobs:
           - lamin_env: "prod"
             python-version: "3.11"
           - lamin_env: "staging"
-            python-version: "3.10" # test on 3.9
+            python-version: "3.10"
     timeout-minutes: 12
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
@@ -97,7 +97,7 @@ jobs:
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: "pip"
@@ -205,7 +205,7 @@ jobs:
           ssh-key: ${{ secrets.READ_LNDOCS }}
           path: lndocs
           ref: main
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: "pip"

--- a/docs/hub-cloud/01-init-local-instance.ipynb
+++ b/docs/hub-cloud/01-init-local-instance.ipynb
@@ -88,11 +88,28 @@
     "assert not storage_root.exists()\n",
     "assert settings_file.exists() is False"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Expand user directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln_setup.init(storage=\"~/mydata\")\n",
+    "ln_setup.delete(\"mydata\", force=True)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "lamindb",
    "language": "python",
    "name": "python3"
   },
@@ -106,12 +123,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "40d3a090f54c6569ab1632332b64b2c03c39dcf918b08424e98f38b5ae0af88f"
-   }
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/docs/hub-cloud/01-init-local-instance.ipynb
+++ b/docs/hub-cloud/01-init-local-instance.ipynb
@@ -88,23 +88,6 @@
     "assert not storage_root.exists()\n",
     "assert settings_file.exists() is False"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Expand user directory"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln_setup.init(storage=\"~/mydata\")\n",
-    "ln_setup.delete(\"mydata\", force=True)"
-   ]
   }
  ],
  "metadata": {

--- a/docs/hub-cloud/07-keep-artifacts-local.ipynb
+++ b/docs/hub-cloud/07-keep-artifacts-local.ipynb
@@ -20,6 +20,7 @@
     "import pytest\n",
     "import lamindb_setup as ln_setup\n",
     "from upath import UPath\n",
+    "from pathlib import Path\n",
     "\n",
     "name = f\"keep-artifacts-local-setup-{os.environ['LAMIN_ENV']}\"\n",
     "storage = (UPath(\"s3://lamindb-ci\") / name).as_posix()\n",
@@ -190,6 +191,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Expand user directory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test expanduser works\n",
+    "test_path = \"~/test/file.txt\"\n",
+    "result = ln_setup.core.upath.create_path(test_path)\n",
+    "expected = UPath(Path(test_path).expanduser())\n",
+    "assert result.as_posix() == expected.as_posix()\n",
+    "\n",
+    "# Test it doesn't affect absolute paths\n",
+    "test_path = \"/absolute/path/file.txt\"\n",
+    "result = ln_setup.core.upath.create_path(test_path)\n",
+    "assert str(result) == test_path"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -201,7 +227,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "lamindb",
    "language": "python",
    "name": "python3"
   },
@@ -215,7 +241,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/docs/hub-cloud/08-test-multi-session.ipynb
+++ b/docs/hub-cloud/08-test-multi-session.ipynb
@@ -178,16 +178,6 @@
     "!lamin delete --force testsetup-prepare\n",
     "!lamin delete --force testsetup"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln_setup.init(storage=\"~/mydata\")\n",
-    "ln_setup.delete(\"mydata\", force=True)"
-   ]
   }
  ],
  "metadata": {

--- a/docs/hub-cloud/08-test-multi-session.ipynb
+++ b/docs/hub-cloud/08-test-multi-session.ipynb
@@ -178,11 +178,21 @@
     "!lamin delete --force testsetup-prepare\n",
     "!lamin delete --force testsetup"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln_setup.init(storage=\"~/mydata\")\n",
+    "ln_setup.delete(\"mydata\", force=True)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "lamindb",
    "language": "python",
    "name": "python3"
   },
@@ -196,7 +206,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/docs/hub-cloud/09-test-init-paths.ipynb
+++ b/docs/hub-cloud/09-test-init-paths.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "58aad301",
+   "metadata": {},
+   "source": [
+    "# Test init paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9776f3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lamindb_setup as ln_setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69c0c8b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln_setup.init(storage=\"~/mydata\")\n",
+    "\n",
+    "assert \"home\" in ln_setup.settings.storage.root.as_posix()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "553472a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln_setup.delete(\"mydata\", force=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lamindb",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/lamindb_setup/core/_settings_storage.py
+++ b/lamindb_setup/core/_settings_storage.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import os
 import secrets
-import shutil
 import string
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import fsspec
@@ -208,7 +206,7 @@ class StorageSettings:
     ):
         self._uid = uid
         self._uuid_ = uuid
-        self._root_init = UPath(root)
+        self._root_init = UPath(root).expanduser()
         if isinstance(self._root_init, LocalPathClasses):  # local paths
             try:
                 (self._root_init / ".lamindb").mkdir(parents=True, exist_ok=True)

--- a/lamindb_setup/core/upath.py
+++ b/lamindb_setup/core/upath.py
@@ -806,7 +806,7 @@ register_implementation("s3", S3QueryPath, clobber=True)
 
 
 def create_path(path: UPathStr, access_token: str | None = None) -> UPath:
-    upath = UPath(path)
+    upath = UPath(path).expanduser()
 
     if upath.protocol == "s3":
         # add managed credentials and other options for AWS s3 paths


### PR DESCRIPTION
`create_path` now expands the user directory by default to support `"~"` characters. Since it uses `UPath`, this has no effect on remote paths. They are returned unchanged. I could have made that change in the `process_data` function of `Artifact` at `path = create_path(data, access_token=access_token)` but I think it fits a bit better here. No strong feelings.

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/5158d566-93e4-4a42-bc14-df508c23ff74) | ![image](https://github.com/user-attachments/assets/beeba365-7d6f-40c4-a5cc-60cca949250b)

This now also works for `init` where we support user directories
