### PR TITLE
🐛 Correct field name in `_select_storage_or_parent`

### DIFF
--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -121,6 +121,7 @@ def _select_storage_or_parent(path: str, client: Client) -> dict | None:
     result = client.rpc("existing_root_or_child", {"_path": path}).execute().data
     if result["root"] is None:
         return None
+    result["uid"] = result.pop("lnid")
     result["instance_uid"] = hash_and_encode_as_b62(
         UUID(result.pop("instance_id")).hex
     )[:12]


### PR DESCRIPTION
It is `uid` in `Storage`, not `lnid`.