### PR TITLE
♻️ No longer install `contenttypes`

### DIFF
--- a/lamindb_setup/core/django.py
+++ b/lamindb_setup/core/django.py
@@ -170,8 +170,7 @@ def setup_django(
 
         module_names = ["core"] + list(isettings.modules)
         raise_import_error = True if init else False
-        installed_apps = ["django.contrib.contenttypes"]
-        installed_apps += [
+        installed_apps = [
             package_name
             for name in module_names
             if (


### PR DESCRIPTION
With the new `TableState` registry in `lamindb`, `contenttypes` is no longer needed. Only the former has implicitly-defined link models.