### PR TITLE
✨ Allow to use all http methods in `request_auth`

### DIFF
--- a/lamindb_setup/core/_hub_client.py
+++ b/lamindb_setup/core/_hub_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from typing import Literal
 from urllib.request import urlretrieve
 
 from gotrue.errors import AuthUnknownError
@@ -197,10 +198,20 @@ def requests_client():
     return requests
 
 
-def request_get_auth(url: str, access_token: str, renew_token: bool = True):
+def request_auth(
+    url: str,
+    method: Literal["get", "post", "put", "delete", "head", "options"],
+    access_token: str,
+    renew_token: bool = True,
+    **kwargs,
+):
     requests = requests_client()
 
-    response = requests.get(url, headers={"Authorization": f"Bearer {access_token}"})
+    headers = kwargs.pop("headers", {})
+    headers["Authorization"] = f"Bearer {access_token}"
+
+    make_request = getattr(requests, method)
+    response = make_request(url, headers=headers, **kwargs)
     # upate access_token and try again if failed
     if response.status_code != 200 and renew_token:
         from lamindb_setup import settings
@@ -212,7 +223,7 @@ def request_get_auth(url: str, access_token: str, renew_token: bool = True):
         settings.user.access_token = access_token
         save_user_settings(settings.user)
 
-        response = requests.get(
-            url, headers={"Authorization": f"Bearer {access_token}"}
-        )
+        headers["Authorization"] = f"Bearer {access_token}"
+
+        response = make_request(url, headers=headers, **kwargs)
     return response

--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -17,7 +17,7 @@ from ._hub_client import (
     call_with_fallback,
     call_with_fallback_auth,
     connect_hub,
-    request_get_auth,
+    request_auth,
 )
 from ._hub_crud import (
     _delete_instance_record,
@@ -495,7 +495,7 @@ def access_db(
             )
         url = instance_api_url + url
 
-    response = request_get_auth(url, access_token, renew_token)  # type: ignore
+    response = request_auth(url, "get", access_token, renew_token)  # type: ignore
     response_json = response.json()
     if response.status_code != 200:
         raise PermissionError(


### PR DESCRIPTION
Introduces `request_auth` instead of `request_get_auth`. `request_auth` can do all types of http requests. Needed to use with https://github.com/laminlabs/laminhub/pull/2618 