### PR TITLE
🚸 Set up Django on every import of lamindb via a "mock instance"

### DIFF
--- a/docs/hub-cloud/08-test-multi-session.ipynb
+++ b/docs/hub-cloud/08-test-multi-session.ipynb
@@ -8,6 +8,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook is complemented by the `faq/setup.ipynb` notebook in lamindb."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -155,7 +162,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "py312",
    "language": "python",
    "name": "python3"
   },
@@ -169,7 +176,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/docs/hub-cloud/08-test-multi-session.ipynb
+++ b/docs/hub-cloud/08-test-multi-session.ipynb
@@ -60,6 +60,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "assert ln_setup.settings.instance.slug == \"testuser1/testsetup\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from lamindb.models import User"
    ]
   },
@@ -111,43 +120,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let us try to init another instance in the same Python session:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from lamindb_setup._init_instance import CannotSwitchDefaultInstance\n",
-    "\n",
-    "with pytest.raises(CannotSwitchDefaultInstance):\n",
-    "    ln_setup.init(storage=\"./testsetup2\")\n",
-    "with pytest.raises(CannotSwitchDefaultInstance):\n",
-    "    ln_setup.connect(\"testsetup\")\n",
-    "with pytest.raises(RuntimeError):\n",
-    "    ln_setup.migrate.create()\n",
-    "with pytest.raises(RuntimeError):\n",
-    "    ln_setup.migrate.deploy()\n",
-    "\n",
-    "assert ln_setup.settings.instance.slug == \"testuser1/testsetup\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Reset `django` and connect to another instance:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln_setup.core.django.reset_django()"
+    "Connect to another instance in the same process:"
    ]
   },
   {

--- a/lamindb_setup/_cache.py
+++ b/lamindb_setup/_cache.py
@@ -5,6 +5,7 @@ import shutil
 from lamin_utils import logger
 
 from .core._settings_save import save_system_storage_settings
+from .errors import CurrentInstanceNotConfigured
 
 
 def clear_cache_dir():
@@ -16,9 +17,8 @@ def clear_cache_dir():
                 "Disconnecting the current instance to update the cloud sqlite database."
             )
             disconnect()
-    except SystemExit as e:
-        if str(e) != "No instance connected! Call `lamin connect` or `lamin init`":
-            raise e
+    except CurrentInstanceNotConfigured:
+        pass
 
     cache_dir = settings.cache_dir
     shutil.rmtree(cache_dir)

--- a/lamindb_setup/_cache.py
+++ b/lamindb_setup/_cache.py
@@ -6,11 +6,9 @@ from pathlib import Path
 from dotenv import dotenv_values
 from lamin_utils import logger
 
-from .core._settings_save import save_system_storage_settings
-from .errors import CurrentInstanceNotConfigured
 from .core._settings_save import save_platform_user_storage_settings
 from .core._settings_store import system_settings_file
-
+from .errors import CurrentInstanceNotConfigured
 
 
 def clear_cache_dir():

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -163,12 +163,7 @@ def _check_instance_setup(from_module: str | None = None) -> bool:
         return True
     isettings = _get_current_instance_settings()
     if isettings is not None:
-        if (
-            from_module is not None
-            and settings.auto_connect
-            and not django_lamin.IS_SETUP
-            and not IS_LOADING
-        ):
+        if from_module is not None and not django_lamin.IS_SETUP and not IS_LOADING:
             if from_module != "lamindb":
                 _check_module_in_instance_modules(from_module, isettings)
 
@@ -181,7 +176,7 @@ def _check_instance_setup(from_module: str | None = None) -> bool:
                     logger.important(f"connected lamindb: {isettings.slug}")
         return django_lamin.IS_SETUP
     else:
-        if from_module is not None and settings.auto_connect:
+        if from_module is not None:
             # the below enables users to auto-connect to an instance
             # simply by setting an environment variable, bypassing the
             # need of calling connect() manually

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -5,6 +5,7 @@ import importlib as il
 import inspect
 import os
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from lamin_utils import logger
 
@@ -43,6 +44,8 @@ def disable_auto_connect(func: Callable):
 
 
 def _get_current_instance_settings() -> InstanceSettings | None:
+    from .core._settings_instance import InstanceSettings
+
     global CURRENT_ISETTINGS
 
     if CURRENT_ISETTINGS is not None:
@@ -62,7 +65,14 @@ def _get_current_instance_settings() -> InstanceSettings | None:
             raise e
         return isettings
     else:
-        return None
+        isettings = InstanceSettings(
+            id=UUID("00000000-0000-0000-0000-000000000000"),
+            owner="none",
+            name="none",
+            storage=None,
+        )
+        logger.warning("not connected to a database instance")
+        return isettings
 
 
 def _normalize_module_name(module_name: str) -> str:

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -154,9 +154,10 @@ def _check_instance_setup(from_module: str | None = None) -> bool:
                 import lamindb
 
                 il.reload(il.import_module(from_module))
-            elif isettings.slug != "none/none":
+            else:
                 django_lamin.setup_django(isettings)
-                logger.important(f"connected lamindb: {isettings.slug}")
+                if isettings.slug != "none/none":
+                    logger.important(f"connected lamindb: {isettings.slug}")
         return django_lamin.IS_SETUP
     else:
         if from_module is not None and settings.auto_connect:

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -71,7 +71,8 @@ def _get_current_instance_settings() -> InstanceSettings:
             name="none",
             storage=None,
         )
-        logger.warning("not connected, call: ln.connect('account/name')")
+        if not IS_LOADING:
+            logger.warning("not connected, call: ln.connect('account/name')")
         return isettings
 
 

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -43,7 +43,7 @@ def disable_auto_connect(func: Callable):
     return wrapper
 
 
-def _get_current_instance_settings() -> InstanceSettings | None:
+def _get_current_instance_settings() -> InstanceSettings:
     from .core._settings_instance import InstanceSettings
 
     global CURRENT_ISETTINGS
@@ -71,7 +71,7 @@ def _get_current_instance_settings() -> InstanceSettings | None:
             name="none",
             storage=None,
         )
-        logger.warning("not connected to a database instance")
+        logger.warning("not connected, call: ln.connect('account/name')")
         return isettings
 
 

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -90,8 +90,6 @@ def _get_current_instance_settings(from_module: str | None = None) -> InstanceSe
             storage=None,
             modules=",".join(module_candidates),
         )
-        if not IS_LOADING:
-            logger.warning("not connected, call: ln.connect('account/name')")
     CURRENT_ISETTINGS = isettings
     return isettings
 
@@ -174,6 +172,8 @@ def _check_instance_setup(from_module: str | None = None) -> bool:
                 django_lamin.setup_django(isettings)
                 if isettings.slug != "none/none":
                     logger.important(f"connected lamindb: {isettings.slug}")
+                else:
+                    logger.warning("not connected, call: ln.connect('account/name')")
         return django_lamin.IS_SETUP
     else:
         if from_module is not None:

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -154,7 +154,7 @@ def _check_instance_setup(from_module: str | None = None) -> bool:
                 import lamindb
 
                 il.reload(il.import_module(from_module))
-            else:
+            elif isettings.slug != "none/none":
                 django_lamin.setup_django(isettings)
                 logger.important(f"connected lamindb: {isettings.slug}")
         return django_lamin.IS_SETUP

--- a/lamindb_setup/_check_setup.py
+++ b/lamindb_setup/_check_setup.py
@@ -172,11 +172,10 @@ def _check_instance_setup(from_module: str | None = None) -> bool:
                 django_lamin.setup_django(isettings)
                 if isettings.slug != "none/none":
                     logger.important(f"connected lamindb: {isettings.slug}")
+                    # update of local storage location through search_local_root()
+                    settings._instance_settings = isettings
                 else:
                     logger.warning("not connected, call: ln.connect('account/name')")
-                settings._instance_settings = (
-                    isettings  # update of local storage location
-                )
         return django_lamin.IS_SETUP
     else:
         if from_module is not None:

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -288,7 +288,7 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
         load_from_isettings(isettings, user=_user, write_settings=_write_settings)
         if _reload_lamindb:
             importlib.reload(importlib.import_module("lamindb"))
-        elif isettings.slug != "none/none":
+        if isettings.slug != "none/none":
             logger.important(f"connected lamindb: {isettings.slug}")
     except Exception as e:
         if isettings is not None:

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -288,7 +288,7 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
         load_from_isettings(isettings, user=_user, write_settings=_write_settings)
         if _reload_lamindb:
             importlib.reload(importlib.import_module("lamindb"))
-        else:
+        elif isettings.slug != "none/none":
             logger.important(f"connected lamindb: {isettings.slug}")
     except Exception as e:
         if isettings is not None:

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -193,9 +193,9 @@ def _connect_instance(
 def reset_django_module_variables():
     import types
 
-    from django.apps import apps
-
-    app_names = {app.name for app in apps.get_app_configs()}
+    app_names = find_module_candidates()
+    app_names.add("lamindb")
+    print(app_names)
     main_modules = {
         k: v
         for k, v in vars(sys.modules["__main__"]).items()

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -304,6 +304,17 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
                 else:
                     from lamindb_setup.core.django import reset_django
 
+                    if settings.instance.slug != "none/none":
+                        import lamindb as ln
+
+                        if ln.context.transform is not None:
+                            raise CannotSwitchDefaultInstance(
+                                "Cannot switch default instance while `ln.track()` is live: call `ln.finish()`"
+                            )
+                        else:
+                            logger.warning(
+                                "switching the current lamindb instance is experimental and might produce unexpected side effects"
+                            )
                     reset_django()
             elif (
                 _write_settings

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -14,10 +14,7 @@ from ._check_setup import (
     find_module_candidates,
 )
 from ._disconnect import disconnect
-from ._init_instance import (
-    MESSAGE_CANNOT_SWITCH_DEFAULT_INSTANCE,
-    load_from_isettings,
-)
+from ._init_instance import load_from_isettings
 from ._silence_loggers import silence_loggers
 from .core._hub_core import connect_instance_hub
 from .core._hub_utils import (
@@ -286,9 +283,9 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
                     logger.important(f"connected lamindb: {settings.instance.slug}")
                     return None
                 else:
-                    raise CannotSwitchDefaultInstance(
-                        MESSAGE_CANNOT_SWITCH_DEFAULT_INSTANCE
-                    )
+                    from lamindb_setup.core.django import reset_django
+
+                    reset_django()
             elif (
                 _write_settings
                 and settings._instance_exists

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -225,12 +225,7 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
 
     try:
         if instance is None:
-            isettings_or_none = _get_current_instance_settings()
-            if isettings_or_none is None:
-                raise ValueError(
-                    "No instance was connected through the CLI, pass a value to `instance` or connect via the CLI."
-                )
-            isettings = isettings_or_none
+            isettings = _get_current_instance_settings()
         else:
             owner, name = get_owner_name_from_identifier(instance)
             if _check_instance_setup() and not _test:

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -234,7 +234,7 @@ def reset_django_module_variables():
             except (AttributeError, TypeError):
                 continue
 
-                
+
 def _connect_cli(instance: str) -> None:
     from lamindb_setup import settings as settings_
 

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -193,9 +193,9 @@ def _connect_instance(
 def reset_django_module_variables():
     import types
 
-    app_names = find_module_candidates()
-    app_names.add("lamindb")
-    print(app_names)
+    from django.apps import apps
+
+    app_names = {app.name for app in apps.get_app_configs()}
     main_modules = {
         k: v
         for k, v in vars(sys.modules["__main__"]).items()

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -264,6 +264,10 @@ def init(
         if _check_instance_setup() and not _test:
             from lamindb_setup.core.django import reset_django
 
+            if settings._instance_exists:
+                raise CannotSwitchDefaultInstance(
+                    "Cannot init new instance after connecting to an existing instance."
+                )
             reset_django()
         elif _write_settings:
             disconnect(mute=True)

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -93,28 +93,28 @@ def register_user(usettings: UserSettings, update_user: bool = True):
 
 def register_initial_records(isettings: InstanceSettings, usettings: UserSettings):
     """Register space, user & storage in DB."""
-    import lamindb as ln
     from django.db.utils import OperationalError
+    from lamindb.models import Branch, Space
 
     try:
-        ln.Space.objects.get_or_create(
+        Space.objects.get_or_create(
             uid="A",
             name="All",
             description="Every team & user with access to the instance has access.",
         )
-        ln.Branch.objects.get_or_create(
+        Branch.objects.get_or_create(
             id=-1,
             uid="T",
             name="Trash",
             description="The trash.",
         )
-        ln.Branch.objects.get_or_create(
+        Branch.objects.get_or_create(
             id=0,
             uid="A",
             name="Archive",
             description="The archive.",
         )
-        ln.Branch.objects.get_or_create(
+        Branch.objects.get_or_create(
             uid="M",
             name="Main",
             description="The main & default branch of the instance.",
@@ -324,7 +324,6 @@ def init(
         if _test:
             return None
         isettings._init_db()
-        reset_django_module_variables()
         load_from_isettings(
             isettings, init=True, user=_user, write_settings=_write_settings
         )
@@ -341,6 +340,7 @@ def init(
         if _write_settings:
             settings.auto_connect = True
         importlib.reload(importlib.import_module("lamindb"))
+        reset_django_module_variables()
         logger.important(f"initialized lamindb: {isettings.slug}")
     except Exception as e:
         from ._delete import delete_by_isettings

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -93,28 +93,28 @@ def register_user(usettings: UserSettings, update_user: bool = True):
 
 def register_initial_records(isettings: InstanceSettings, usettings: UserSettings):
     """Register space, user & storage in DB."""
+    import lamindb as ln
     from django.db.utils import OperationalError
-    from lamindb.models import Branch, Space
 
     try:
-        Space.objects.get_or_create(
+        ln.Space.objects.get_or_create(
             uid="A",
             name="All",
             description="Every team & user with access to the instance has access.",
         )
-        Branch.objects.get_or_create(
+        ln.Branch.objects.get_or_create(
             id=-1,
             uid="T",
             name="Trash",
             description="The trash.",
         )
-        Branch.objects.get_or_create(
+        ln.Branch.objects.get_or_create(
             id=0,
             uid="A",
             name="Archive",
             description="The archive.",
         )
-        Branch.objects.get_or_create(
+        ln.Branch.objects.get_or_create(
             uid="M",
             name="Main",
             description="The main & default branch of the instance.",
@@ -324,6 +324,7 @@ def init(
         if _test:
             return None
         isettings._init_db()
+        reset_django_module_variables()
         load_from_isettings(
             isettings, init=True, user=_user, write_settings=_write_settings
         )
@@ -340,7 +341,6 @@ def init(
         if _write_settings:
             settings.auto_connect = True
         importlib.reload(importlib.import_module("lamindb"))
-        reset_django_module_variables()
         logger.important(f"initialized lamindb: {isettings.slug}")
     except Exception as e:
         from ._delete import delete_by_isettings

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -215,16 +215,6 @@ def validate_init_args(
     return name_str, instance_id, instance_state, instance_slug
 
 
-MESSAGE_CANNOT_SWITCH_DEFAULT_INSTANCE = """
-You cannot write to different instances in the same Python session.
-
-Do you want to read from another instance via `SQLRecord.using()`? For example:
-
-ln.Artifact.using("laminlabs/cellxgene").filter()
-
-Or do you want to switch off auto-connect via `lamin settings set auto-connect false`?
-"""
-
 DOC_STORAGE_ARG = "A local or remote folder (`'s3://...'` or `'gs://...'`). Defaults to current working directory."
 DOC_INSTANCE_NAME = (
     "Instance name. If not passed, it will equal the folder name passed to `storage`."
@@ -272,7 +262,9 @@ def init(
         from ._check_setup import _check_instance_setup
 
         if _check_instance_setup() and not _test:
-            raise CannotSwitchDefaultInstance(MESSAGE_CANNOT_SWITCH_DEFAULT_INSTANCE)
+            from lamindb_setup.core.django import reset_django
+
+            reset_django()
         elif _write_settings:
             disconnect(mute=True)
         from ._connect_instance import reset_django_module_variables

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -267,6 +267,7 @@ def init(
             reset_django()
         elif _write_settings:
             disconnect(mute=True)
+        from ._connect_instance import reset_django_module_variables
         from .core._hub_core import init_instance_hub
 
         name_str, instance_id, instance_state, _ = validate_init_args(
@@ -339,6 +340,7 @@ def init(
         if _write_settings:
             settings.auto_connect = True
         importlib.reload(importlib.import_module("lamindb"))
+        reset_django_module_variables()
         logger.important(f"initialized lamindb: {isettings.slug}")
     except Exception as e:
         from ._delete import delete_by_isettings

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -280,8 +280,6 @@ def init(
             _user=_user,  # will get from settings.user if _user is None
         )
         if instance_state == "connected":
-            if _write_settings:
-                settings.auto_connect = True  # we can also debate this switch here
             return None
         prevent_register_hub = is_local_db_url(db) if db is not None else False
         ssettings, _ = init_storage(
@@ -337,8 +335,6 @@ def init(
             from ._schema_metadata import update_schema_in_hub
 
             update_schema_in_hub(access_token=access_token)
-        if _write_settings:
-            settings.auto_connect = True
         importlib.reload(importlib.import_module("lamindb"))
         reset_django_module_variables()
         logger.important(f"initialized lamindb: {isettings.slug}")

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -207,7 +207,7 @@ class SetupSettings:
         if self._instance_exists:
             repr += self.instance.__repr__()
         else:
-            repr += "\nNo instance connected"
+            repr += "\nCurrent instance not configured"
         return repr
 
 

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -91,9 +91,9 @@ class SetupSettings:
 
     @auto_connect.setter
     def auto_connect(self, value: bool) -> None:
-        logger.warning(
-            "setting auto_connect to `False` no longer has an effect and the setting will likely be removed in the future; since lamindb 1.7, auto_connect `True` no longer clashes with connecting in a Python session",
-        )
+        # logger.warning(
+        #     "setting auto_connect to `False` no longer has an effect and the setting will likely be removed in the future; since lamindb 1.7, auto_connect `True` no longer clashes with connecting in a Python session",
+        # )
         if value:
             self._auto_connect_path.touch()
         else:

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -76,7 +76,8 @@ class SetupSettings:
         - in Python: `ln.setup.settings.auto_connect = True/False`
         - via the CLI: `lamin settings set auto-connect true/false`
         """
-        return self._auto_connect_path.exists()
+        # always true now because we can switch instances
+        return True
 
     @auto_connect.setter
     def auto_connect(self, value: bool) -> None:

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -98,9 +98,10 @@ class SetupSettings:
         If `True`, the current instance is connected, meaning that the db and other settings
         are properly configured for use.
         """
-        from .django import IS_SETUP  # always import to protect from assignment
-
-        return IS_SETUP
+        if self._instance_exists:
+            return self.instance.slug != "none/none"
+        else:
+            return False
 
     @property
     def private_django_api(self) -> bool:

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 from appdirs import AppDirs
 from lamin_utils import logger
 
+from lamindb_setup.errors import CurrentInstanceNotConfigured
+
 from ._settings_load import (
     load_instance_settings,
     load_or_create_user_settings,
@@ -158,7 +160,7 @@ class SetupSettings:
             self.instance  # noqa
             return True
         # this is implicit logic that catches if no instance is loaded
-        except SystemExit:
+        except CurrentInstanceNotConfigured:
             return False
 
     @property
@@ -207,7 +209,7 @@ class SetupSettings:
         if self._instance_exists:
             repr += self.instance.__repr__()
         else:
-            repr += "\nCurrent instance not configured"
+            repr += f"\n{CurrentInstanceNotConfigured.default_message}"
         return repr
 
 

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import warnings
 from typing import TYPE_CHECKING
 
 from appdirs import AppDirs
@@ -78,11 +79,13 @@ class SetupSettings:
         - in Python: `ln.setup.settings.auto_connect = True/False`
         - via the CLI: `lamin settings set auto-connect true/false`
         """
-        # always true now because we can switch instances
         return True
 
     @auto_connect.setter
     def auto_connect(self, value: bool) -> None:
+        logger.warning(
+            "setting auto_connect to `False` no longer has an effect and the setting will likely be removed in the future; since lamindb 1.7, auto_connect `True` no longer clashes with connecting in a Python session",
+        )
         if value:
             self._auto_connect_path.touch()
         else:

--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -464,7 +464,7 @@ class InstanceSettings:
             write_to_disk: Save these instance settings to disk and
                 overwrite the current instance settings file.
         """
-        if write_to_disk:
+        if write_to_disk and self.slug != "none/none":
             assert self.name is not None
             filepath = self._get_settings_file()
             # persist under filepath for later reference

--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -56,7 +56,7 @@ class InstanceSettings:
         id: UUID,  # instance id/uuid
         owner: str,  # owner handle
         name: str,  # instance name
-        storage: StorageSettings,  # storage location
+        storage: StorageSettings | None,  # storage location
         keep_artifacts_local: bool = False,  # default to local storage
         uid: str | None = None,  # instance uid/lnid
         db: str | None = None,  # DB URI
@@ -75,7 +75,7 @@ class InstanceSettings:
         self._owner: str = owner
         self._name: str = name
         self._uid: str | None = uid
-        self._storage: StorageSettings = storage
+        self._storage: StorageSettings | None = storage
         validate_db_arg(db)
         self._db: str | None = db
         self._schema_str: str | None = modules
@@ -204,7 +204,7 @@ class InstanceSettings:
         For a cloud instance, this is cloud storage. For a local instance, this
         is a local directory.
         """
-        return self._storage
+        return self._storage  # type: ignore
 
     @property
     def storage_local(self) -> StorageSettings:
@@ -370,6 +370,8 @@ class InstanceSettings:
                 "It overwrites all db connections and is used instead of `instance.db`."
             )
         if self._db is None:
+            if self._storage is None:
+                return "sqlite:///:memory:"
             # here, we want the updated sqlite file
             # hence, we don't use self._sqlite_file_local()
             # error_no_origin=False because on instance init

--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -370,7 +370,9 @@ class InstanceSettings:
                 "It overwrites all db connections and is used instead of `instance.db`."
             )
         if self._db is None:
-            if self._storage is None:
+            from .django import IS_SETUP
+
+            if self._storage is None and self.slug == "none/none":
                 return "sqlite:///:memory:"
             # here, we want the updated sqlite file
             # hence, we don't use self._sqlite_file_local()

--- a/lamindb_setup/core/_settings_load.py
+++ b/lamindb_setup/core/_settings_load.py
@@ -8,7 +8,7 @@ from dotenv import dotenv_values
 from lamin_utils import logger
 from pydantic import ValidationError
 
-from lamindb_setup.errors import SettingsEnvFileOutdated
+from lamindb_setup.errors import CurrentInstanceNotConfigured, SettingsEnvFileOutdated
 
 from ._settings_instance import InstanceSettings
 from ._settings_storage import StorageSettings
@@ -39,7 +39,7 @@ def load_instance_settings(instance_settings_file: Path | None = None):
     if instance_settings_file is None:
         instance_settings_file = current_instance_settings_file()
     if not instance_settings_file.exists():
-        raise SystemExit("No instance connected! Call `lamin connect` or `lamin init`")
+        raise CurrentInstanceNotConfigured
     try:
         settings_store = InstanceSettingsStore(_env_file=instance_settings_file)
     except (ValidationError, TypeError) as error:

--- a/lamindb_setup/core/django.py
+++ b/lamindb_setup/core/django.py
@@ -155,6 +155,7 @@ def setup_django(
 
     import dj_database_url
     import django
+    from django.apps import apps
     from django.conf import settings
     from django.core.management import call_command
 
@@ -213,6 +214,9 @@ def setup_django(
                 STATIC_URL="static/",
             )
         settings.configure(**kwargs)
+        # this isn't needed the first time django.setup() is called, but for unknown reason it's needed the second time
+        # the first time, it already defaults to true
+        apps.apps_ready = True
         django.setup(set_prefix=False)
         # https://laminlabs.slack.com/archives/C04FPE8V01W/p1698239551460289
         from django.db.backends.base.base import BaseDatabaseWrapper
@@ -273,6 +277,7 @@ def reset_django():
     app_names = {"django"} | {app.name for app in apps.get_app_configs()}
 
     apps.app_configs.clear()
+    apps.all_models.clear()
     apps.apps_ready = apps.models_ready = apps.ready = apps.loading = False
     apps.clear_cache()
 

--- a/lamindb_setup/core/django.py
+++ b/lamindb_setup/core/django.py
@@ -278,9 +278,9 @@ def reset_django():
 
     # i suspect it is enough to just drop django and all the apps from sys.modules
     # the code above is just a precaution
-    # for module_name in list(sys.modules):
-    #     if module_name.partition(".")[0] in app_names:
-    #         del sys.modules[module_name]
+    for module_name in list(sys.modules):
+        if module_name.partition(".")[0] in app_names:
+            del sys.modules[module_name]
 
     il.invalidate_caches()
 

--- a/lamindb_setup/core/django.py
+++ b/lamindb_setup/core/django.py
@@ -278,9 +278,9 @@ def reset_django():
 
     # i suspect it is enough to just drop django and all the apps from sys.modules
     # the code above is just a precaution
-    for module_name in list(sys.modules):
-        if module_name.partition(".")[0] in app_names:
-            del sys.modules[module_name]
+    # for module_name in list(sys.modules):
+    #     if module_name.partition(".")[0] in app_names:
+    #         del sys.modules[module_name]
 
     il.invalidate_caches()
 

--- a/lamindb_setup/core/django.py
+++ b/lamindb_setup/core/django.py
@@ -140,16 +140,6 @@ def close_if_health_check_failed(self) -> None:
         self.close_at = time.monotonic() + CONN_MAX_AGE
 
 
-def clear_django_apps_cache():
-    """Clear Django apps cache."""
-    from django.apps import apps
-
-    apps.app_configs.clear()
-    apps.apps_ready = apps.models_ready = apps.ready = apps.loading = False
-    apps.clear_cache()
-    logger.debug("django apps cache has been cleared.")
-
-
 # this bundles set up and migration management
 def setup_django(
     isettings: InstanceSettings,
@@ -165,7 +155,6 @@ def setup_django(
 
     import dj_database_url
     import django
-    from django.apps import apps
     from django.conf import settings
     from django.core.management import call_command
 
@@ -200,7 +189,7 @@ def setup_django(
             installed_apps += ["schema_graph", "django.contrib.staticfiles"]
 
         kwargs = dict(
-            INSTALLED_APPS=[],
+            INSTALLED_APPS=installed_apps,
             DATABASES=DATABASES,
             DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
             TIME_ZONE="UTC",
@@ -225,9 +214,6 @@ def setup_django(
             )
         settings.configure(**kwargs)
         django.setup(set_prefix=False)
-        from django.apps import apps
-
-        apps.populate(settings.INSTALLED_APPS)
         # https://laminlabs.slack.com/archives/C04FPE8V01W/p1698239551460289
         from django.db.backends.base.base import BaseDatabaseWrapper
 
@@ -286,7 +272,9 @@ def reset_django():
 
     app_names = {"django"} | {app.name for app in apps.get_app_configs()}
 
-    clear_django_apps_cache()
+    apps.app_configs.clear()
+    apps.apps_ready = apps.models_ready = apps.ready = apps.loading = False
+    apps.clear_cache()
 
     # i suspect it is enough to just drop django and all the apps from sys.modules
     # the code above is just a precaution

--- a/lamindb_setup/errors.py
+++ b/lamindb_setup/errors.py
@@ -27,6 +27,7 @@ class DefaultMessageException(Exception):
         super().__init__(message)
 
 
+# TODO: remove this exception sooner or later because we don't have a need for it anymore
 class InstanceNotSetupError(DefaultMessageException):
     default_message = """\
 To use lamindb, you need to connect to an instance.

--- a/lamindb_setup/errors.py
+++ b/lamindb_setup/errors.py
@@ -37,6 +37,12 @@ If you used the CLI to set up lamindb in a notebook, restart the Python session.
 """
 
 
+class CurrentInstanceNotConfigured(DefaultMessageException):
+    default_message = (
+        """Current instance is not configured! Call `lamin connect` or `lamin init`"""
+    )
+
+
 MODULE_WASNT_CONFIGURED_MESSAGE_TEMPLATE = (
     "'{}' wasn't configured for this instance -- "
     "if you want it, go to your instance settings page and add it under 'schema modules' (or ask an admin to do so)"

--- a/lamindb_setup/errors.py
+++ b/lamindb_setup/errors.py
@@ -3,6 +3,7 @@
 .. autosummary::
    :toctree: .
 
+   CurrentInstanceNotConfigured
    InstanceNotSetupError
    ModuleWasntConfigured
    StorageAlreadyManaged

--- a/lamindb_setup/errors.py
+++ b/lamindb_setup/errors.py
@@ -40,9 +40,11 @@ If you used the CLI to set up lamindb in a notebook, restart the Python session.
 
 
 class CurrentInstanceNotConfigured(DefaultMessageException):
-    default_message = (
-        """Current instance is not configured! Call `lamin connect` or `lamin init`"""
-    )
+    default_message = """\
+No instance is connected! Call
+- CLI:     lamin connect / lamin init
+- Python:  ln.connect()  / ln.setup.init()
+- R:       ln$connect()  / ln$setup$init()"""
 
 
 MODULE_WASNT_CONFIGURED_MESSAGE_TEMPLATE = (

--- a/tests/hub-cloud/scripts/script-to-fail-managed-storage.py
+++ b/tests/hub-cloud/scripts/script-to-fail-managed-storage.py
@@ -7,7 +7,7 @@ from lamindb_setup._set_managed_storage import set_managed_storage
 from lamindb_setup.core._hub_client import connect_hub_with_auth
 
 # a user should have read-only access to laminlabs/lamin-site-assets
-ln_setup.login("testuser1")
+ln_setup.login("testuser2")
 ln_setup.connect("laminlabs/lamin-site-assets")
 
 test_root = Path("./test_script_ci_storage").resolve().as_posix()

--- a/tests/hub-cloud/scripts/script-to-fail-managed-storage.py
+++ b/tests/hub-cloud/scripts/script-to-fail-managed-storage.py
@@ -7,7 +7,7 @@ from lamindb_setup._set_managed_storage import set_managed_storage
 from lamindb_setup.core._hub_client import connect_hub_with_auth
 
 # a user should have read-only access to laminlabs/lamin-site-assets
-ln_setup.login("testuser2")
+ln_setup.login("testuser1")
 ln_setup.connect("laminlabs/lamin-site-assets")
 
 test_root = Path("./test_script_ci_storage").resolve().as_posix()

--- a/tests/hub-cloud/test_connect_instance.py
+++ b/tests/hub-cloud/test_connect_instance.py
@@ -12,23 +12,9 @@ from laminhub_rest.core.legacy._instance_collaborator import InstanceCollaborato
 from postgrest.exceptions import APIError
 
 
-@pytest.fixture
-def ccaplog(caplog):
-    """Add caplog handler to our custom logger at session start."""
-    from lamin_utils._logger import logger
-
-    # Add caplog's handler to our custom logger
-    logger.addHandler(caplog.handler)
-
-    yield caplog
-
-    # Clean up at the end of the session
-    logger.removeHandler(caplog.handler)
-
-
-def test_connect_pass_none(ccaplog):
+def test_connect_pass_none():
+    # this doesn't log anything
     ln_setup.connect(_test=True)
-    assert "not connected, call: ln.connect('account/name')" in ccaplog.text
 
 
 # do not call hub if the owner is set to anonymous

--- a/tests/hub-cloud/test_connect_instance.py
+++ b/tests/hub-cloud/test_connect_instance.py
@@ -13,7 +13,7 @@ from postgrest.exceptions import APIError
 
 
 def test_connect_pass_none():
-    # this doesn't log anything
+    # this doesn't log anything and connects to the mock instance
     ln_setup.connect(_test=True)
 
 

--- a/tests/hub-cloud/test_connect_instance.py
+++ b/tests/hub-cloud/test_connect_instance.py
@@ -11,13 +11,23 @@ from laminhub_rest.core.legacy._instance_collaborator import InstanceCollaborato
 from postgrest.exceptions import APIError
 
 
-def test_connect_pass_none():
-    with pytest.raises(ValueError) as err:
-        ln_setup.connect(_test=True)
-    assert (
-        err.exconly()
-        == "ValueError: No instance was connected through the CLI, pass a value to `instance` or connect via the CLI."
-    )
+@pytest.fixture
+def ccaplog(caplog):
+    """Add caplog handler to our custom logger at session start."""
+    from lamin_utils._logger import logger
+
+    # Add caplog's handler to our custom logger
+    logger.addHandler(caplog.handler)
+
+    yield caplog
+
+    # Clean up at the end of the session
+    logger.removeHandler(caplog.handler)
+
+
+def test_connect_pass_none(ccaplog):
+    ln_setup.connect(_test=True)
+    assert "not connected, call: ln.connect('account/name')" in ccaplog.text
 
 
 # do not call hub if the owner is set to anonymous


### PR DESCRIPTION
The change here should allow us to eliminate the conditional import in the lamindb root module.

- https://github.com/laminlabs/lamindb/pull/2851

This PR fixes several issues with the reset logic introduced here:

- https://github.com/laminlabs/lamindb-setup/pull/1046

Stale class issue: https://claude.ai/share/b4b3dcb5-4685-42dc-8e32-50851d41c5ac