### PR TITLE
✨ Allow to specify system-wide cache path

### DIFF
--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -19,7 +19,7 @@
     "from platformdirs import user_config_dir\n",
     "\n",
     "# otherwise writing to system_settings_file() fails\n",
-    "os.environ[\"XDG_CONFIG_HOME\"] = user_config_dir()\n",
+    "os.environ[\"XDG_CONFIG_DIRS\"] = user_config_dir()\n",
     "\n",
     "import lamindb_setup as ln_setup\n",
     "from lamindb_setup._cache import set_cache_dir\n",

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -84,12 +84,44 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0fe69c33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "initial_cache_dir = ln_setup.settings.cache_dir\n",
+    "system_cache_dir = initial_cache_dir.parent / \"Cache_system\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90126758",
+   "metadata": {},
+   "source": [
+    "You can specify system-wide cache dir via system settings file, it has the lowest priority."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58fe268f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_settings = system_settings_file()\n",
+    "system_settings.parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "with open(system_settings, \"w\") as f:\n",
+    "    f.write(f\"lamindb_cache_path={system_cache_dir.as_posix()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "511a73d4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "old_cache_dir = ln_setup.settings.cache_dir\n",
-    "new_cache_dir = old_cache_dir.parent / \"Cache1\""
+    "new_cache_dir = initial_cache_dir.parent / \"Cache1\""
    ]
   },
   {
@@ -207,7 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert ln_setup.settings.cache_dir == old_cache_dir"
+    "assert ln_setup.settings.cache_dir == system_cache_dir"
    ]
   },
   {
@@ -227,51 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert ln_setup.settings.cache_dir == old_cache_dir"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a4de1b2b",
-   "metadata": {},
-   "source": [
-    "Setting the cache dir through CLI doesn't affect the currently loaded settings because it is done in another process and the settings only check the cache dir in `settings.env` on init."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ace65de1",
-   "metadata": {},
-   "source": [
-    "You can also specify system-wide cache dir via system settings file, it has the highest priority."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9a856b84",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "system_settings = system_settings_file()\n",
-    "system_settings.parent.mkdir(parents=True, exist_ok=True)\n",
-    "\n",
-    "with open(system_settings, \"w\") as f:\n",
-    "    f.write(f\"lamindb_cache_path={new_cache_dir.as_posix()}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "533e5615",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln_setup.settings._cache_dir = None  # reset the cached cache_dir\n",
-    "\n",
-    "assert ln_setup.settings.cache_dir == new_cache_dir\n",
-    "\n",
-    "ln_setup.settings._cache_dir = None  # reset the cached cache_dir"
+    "assert ln_setup.settings.cache_dir == system_cache_dir"
    ]
   },
   {
@@ -291,7 +279,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert ln_setup.settings.cache_dir == old_cache_dir"
+    "ln_setup.settings._cache_dir = None\n",
+    "assert ln_setup.settings.cache_dir == initial_cache_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57c74240",
+   "metadata": {},
+   "source": [
+    "Setting the cache dir through CLI doesn't affect the currently loaded settings because it is done in another process and the settings only check the cache dir in `settings.env` on init."
    ]
   },
   {

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -16,6 +16,11 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "from platformdirs import user_config_dir\n",
+    "\n",
+    "# otherwise writing to system_settings_file() fails\n",
+    "os.environ[\"XDG_CONFIG_HOME\"] = user_config_dir()\n",
+    "\n",
     "import lamindb_setup as ln_setup\n",
     "from lamindb_setup._cache import set_cache_dir\n",
     "from lamindb_setup.core._settings_store import (\n",

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -18,7 +18,10 @@
     "import os\n",
     "import lamindb_setup as ln_setup\n",
     "from lamindb_setup._cache import set_cache_dir\n",
-    "from lamindb_setup.core._settings_store import platform_user_storage_settings_file\n",
+    "from lamindb_setup.core._settings_store import (\n",
+    "    platform_user_storage_settings_file,\n",
+    "    system_settings_file,\n",
+    ")\n",
     "\n",
     "ln_setup.login(\"testuser2\")"
    ]
@@ -215,6 +218,61 @@
    "metadata": {},
    "source": [
     "Setting the cache dir through CLI doesn't affect the currently loaded settings because it is done in another process and the settings only check the cache dir in `settings.env` on init."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ace65de1",
+   "metadata": {},
+   "source": [
+    "You can also specify system-wide cache dir via system settings file, it has the highest priority."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a856b84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_settings = system_settings_file()\n",
+    "\n",
+    "with open(system_settings, \"w\") as f:\n",
+    "    f.write(f\"lamindb_cache_path={new_cache_dir.as_posix()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "533e5615",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln_setup.settings._cache_dir = None\n",
+    "\n",
+    "assert ln_setup.settings.cache_dir == new_cache_dir\n",
+    "\n",
+    "ln_setup.settings._cache_dir = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e08abf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_settings.unlink()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e86fc4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert ln_setup.settings.cache_dir == old_cache_dir"
    ]
   },
   {

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -167,7 +167,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert ln_setup.settings.cache_dir == new_cache_dir"
+    "assert ln_setup.settings.cache_dir == new_cache_dir, ln_setup.settings.cache_dir"
    ]
   },
   {

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -16,6 +16,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "from dotenv import dotenv_values\n",
     "from platformdirs import user_config_dir\n",
     "\n",
     "# otherwise writing to system_settings_file() fails\n",
@@ -157,7 +158,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert platform_user_storage_settings_file().exists()"
+    "platform_user_storage_settings = platform_user_storage_settings_file()\n",
+    "\n",
+    "assert platform_user_storage_settings.exists()\n",
+    "\n",
+    "lamindb_cache_path = dotenv_values(platform_user_storage_settings)[\"lamindb_cache_path\"]\n",
+    "\n",
+    "assert lamindb_cache_path == new_cache_dir.as_posix(), lamindb_cache_path"
    ]
   },
   {

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -201,7 +201,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!lamin cache clear"
+    "exit_status = os.system(\"lamin cache clear\")\n",
+    "assert exit_status == 0"
    ]
   },
   {
@@ -211,7 +212,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert not any(new_cache_dir.iterdir())"
+    "cache_content = list(new_cache_dir.iterdir())\n",
+    "assert len(cache_content) == 0, cache_content"
    ]
   },
   {

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -91,7 +91,9 @@
    "outputs": [],
    "source": [
     "initial_cache_dir = ln_setup.settings.cache_dir\n",
-    "system_cache_dir = initial_cache_dir.parent / \"Cache_system\""
+    "\n",
+    "system_cache_dir = initial_cache_dir.parent / \"Cache_system\"\n",
+    "system_cache_dir.mkdir(parents=True, exist_ok=True)"
    ]
   },
   {
@@ -114,6 +116,18 @@
     "\n",
     "with open(system_settings, \"w\") as f:\n",
     "    f.write(f\"lamindb_cache_path={system_cache_dir.as_posix()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58de6e01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln_setup.settings._cache_dir = None\n",
+    "\n",
+    "assert ln_setup.settings.cache_dir == system_cache_dir"
    ]
   },
   {

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -29,6 +29,7 @@
     "    platform_user_storage_settings_file,\n",
     "    system_settings_file,\n",
     ")\n",
+    "from lamindb_setup.core._settings_load import load_cache_path_from_settings\n",
     "\n",
     "ln_setup.login(\"testuser2\")"
    ]
@@ -165,6 +166,18 @@
     "lamindb_cache_path = dotenv_values(platform_user_storage_settings)[\"lamindb_cache_path\"]\n",
     "\n",
     "assert lamindb_cache_path == new_cache_dir.as_posix(), lamindb_cache_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb75539e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loaded_cache_path = load_cache_path_from_settings()\n",
+    "\n",
+    "assert loaded_cache_path == new_cache_dir, loaded_cache_path"
    ]
   },
   {

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -18,7 +18,7 @@
     "import os\n",
     "import lamindb_setup as ln_setup\n",
     "from lamindb_setup._cache import set_cache_dir\n",
-    "from lamindb_setup.core._settings_store import user_storage_settings_file\n",
+    "from lamindb_setup.core._settings_store import platform_user_storage_settings_file\n",
     "\n",
     "ln_setup.login(\"testuser2\")"
    ]
@@ -30,8 +30,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if user_storage_settings_file().exists():\n",
-    "    user_storage_settings_file().unlink()"
+    "if platform_user_storage_settings_file().exists():\n",
+    "    platform_user_storage_settings_file().unlink()"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert not user_storage_settings_file().exists()"
+    "assert not platform_user_storage_settings_file().exists()"
    ]
   },
   {
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert user_storage_settings_file().exists()"
+    "assert platform_user_storage_settings_file().exists()"
    ]
   },
   {
@@ -252,7 +252,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "user_storage_settings_file().unlink()\n",
+    "platform_user_storage_settings_file().unlink()\n",
     "ln_setup.delete(\"test-cache\", force=True)"
    ]
   }

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -143,7 +143,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "set_cache_dir(new_cache_dir)"
+    "set_cache_dir(new_cache_dir)\n",
+    "\n",
+    "ln_setup.settings._cache_dir = (\n",
+    "    None  # just reset to check that the cache dir is loaded correctly\n",
+    ")"
    ]
   },
   {

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -21,6 +21,7 @@
     "# otherwise writing to system_settings_file() fails\n",
     "os.environ[\"XDG_CONFIG_DIRS\"] = user_config_dir()\n",
     "\n",
+    "import pytest\n",
     "import lamindb_setup as ln_setup\n",
     "from lamindb_setup._cache import set_cache_dir\n",
     "from lamindb_setup.core._settings_store import (\n",
@@ -89,6 +90,18 @@
    "source": [
     "old_cache_dir = ln_setup.settings.cache_dir\n",
     "new_cache_dir = old_cache_dir.parent / \"Cache1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f809a95f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with pytest.raises(ValueError) as error:\n",
+    "    set_cache_dir(\"./\")\n",
+    "assert error.exconly() == \"ValueError: A path to the cache dir should be absolute.\""
    ]
   },
   {
@@ -254,11 +267,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln_setup.settings._cache_dir = None\n",
+    "ln_setup.settings._cache_dir = None  # reset the cached cache_dir\n",
     "\n",
     "assert ln_setup.settings.cache_dir == new_cache_dir\n",
     "\n",
-    "ln_setup.settings._cache_dir = None"
+    "ln_setup.settings._cache_dir = None  # reset the cached cache_dir"
    ]
   },
   {

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -18,7 +18,7 @@
     "import os\n",
     "import lamindb_setup as ln_setup\n",
     "from lamindb_setup._cache import set_cache_dir\n",
-    "from lamindb_setup.core._settings_store import system_storage_settings_file\n",
+    "from lamindb_setup.core._settings_store import user_storage_settings_file\n",
     "\n",
     "ln_setup.login(\"testuser2\")"
    ]
@@ -30,8 +30,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if system_storage_settings_file().exists():\n",
-    "    system_storage_settings_file().unlink()"
+    "if user_storage_settings_file().exists():\n",
+    "    user_storage_settings_file().unlink()"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert not system_storage_settings_file().exists()"
+    "assert not user_storage_settings_file().exists()"
    ]
   },
   {
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert system_storage_settings_file().exists()"
+    "assert user_storage_settings_file().exists()"
    ]
   },
   {
@@ -252,7 +252,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "system_storage_settings_file().unlink()\n",
+    "user_storage_settings_file().unlink()\n",
     "ln_setup.delete(\"test-cache\", force=True)"
    ]
   }

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -236,6 +236,7 @@
    "outputs": [],
    "source": [
     "system_settings = system_settings_file()\n",
+    "system_settings.parent.mkdir(parents=True, exist_ok=True)\n",
     "\n",
     "with open(system_settings, \"w\") as f:\n",
     "    f.write(f\"lamindb_cache_path={new_cache_dir.as_posix()}\")"

--- a/docs/hub-prod/test-cache-management.ipynb
+++ b/docs/hub-prod/test-cache-management.ipynb
@@ -45,6 +45,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f984eac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(ln_setup.settings)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "fc410abd",
    "metadata": {},
@@ -273,7 +283,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/lamindb_setup/_cache.py
+++ b/lamindb_setup/_cache.py
@@ -4,7 +4,7 @@ import shutil
 
 from lamin_utils import logger
 
-from .core._settings_save import save_user_storage_settings
+from .core._settings_save import save_platform_user_storage_settings
 
 
 def clear_cache_dir():
@@ -48,5 +48,5 @@ def set_cache_dir(cache_dir: str):
         shutil.rmtree(old_cache_dir)
         logger.info("The current cache directory was moved to the specified location")
     new_cache_dir = new_cache_dir.resolve()
-    save_user_storage_settings(new_cache_dir)
+    save_platform_user_storage_settings(new_cache_dir)
     settings._cache_dir = new_cache_dir

--- a/lamindb_setup/_cache.py
+++ b/lamindb_setup/_cache.py
@@ -44,9 +44,14 @@ def set_cache_dir(cache_dir: str):
     if new_cache_dir is None:
         new_cache_dir = DEFAULT_CACHE_DIR
     if new_cache_dir != old_cache_dir:
-        shutil.copytree(old_cache_dir, new_cache_dir, dirs_exist_ok=True)
-        shutil.rmtree(old_cache_dir)
-        logger.info("The current cache directory was moved to the specified location")
+        if old_cache_dir.exists():
+            shutil.copytree(old_cache_dir, new_cache_dir, dirs_exist_ok=True)
+            shutil.rmtree(old_cache_dir)
+            logger.info(
+                "The current cache directory was moved to the specified location"
+            )
+        else:
+            new_cache_dir.mkdir(parents=True, exist_ok=True)
     new_cache_dir = new_cache_dir.resolve()
     save_platform_user_storage_settings(new_cache_dir)
     settings._cache_dir = new_cache_dir

--- a/lamindb_setup/_cache.py
+++ b/lamindb_setup/_cache.py
@@ -68,7 +68,7 @@ def set_cache_dir(cache_dir: str):
         if old_cache_dir.exists():
             shutil.copytree(old_cache_dir, new_cache_dir, dirs_exist_ok=True)
             logger.info(
-                f"the current cache directory was moved to {new_cache_dir.as_posix()} "
+                f"the current cache directory was copied to {new_cache_dir.as_posix()} "
             )
             if old_cache_dir != system_cache_dir:
                 shutil.rmtree(old_cache_dir)

--- a/lamindb_setup/_cache.py
+++ b/lamindb_setup/_cache.py
@@ -4,7 +4,7 @@ import shutil
 
 from lamin_utils import logger
 
-from .core._settings_save import save_system_storage_settings
+from .core._settings_save import save_user_storage_settings
 
 
 def clear_cache_dir():
@@ -48,5 +48,5 @@ def set_cache_dir(cache_dir: str):
         shutil.rmtree(old_cache_dir)
         logger.info("The current cache directory was moved to the specified location")
     new_cache_dir = new_cache_dir.resolve()
-    save_system_storage_settings(new_cache_dir)
+    save_user_storage_settings(new_cache_dir)
     settings._cache_dir = new_cache_dir

--- a/lamindb_setup/_cache.py
+++ b/lamindb_setup/_cache.py
@@ -16,7 +16,7 @@ def clear_cache_dir():
     try:
         if settings.instance._is_cloud_sqlite:
             logger.warning(
-                "Disconnecting the current instance to update the cloud sqlite database."
+                "disconnecting the current instance to update the cloud sqlite database."
             )
             disconnect()
     except SystemExit as e:

--- a/lamindb_setup/_cache.py
+++ b/lamindb_setup/_cache.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import shutil
+from pathlib import Path
 
+from dotenv import dotenv_values
 from lamin_utils import logger
 
 from .core._settings_save import save_platform_user_storage_settings
+from .core._settings_store import system_settings_file
 
 
 def clear_cache_dir():
@@ -24,7 +27,9 @@ def clear_cache_dir():
     if cache_dir.exists():
         shutil.rmtree(cache_dir)
         cache_dir.mkdir()
-        logger.success("The cache directory was cleared.")
+        logger.success("the cache directory was cleared")
+    else:
+        logger.warning("the cache directory doesn't exist")
 
 
 def get_cache_dir():
@@ -42,17 +47,41 @@ def set_cache_dir(cache_dir: str):
 
     old_cache_dir = settings.cache_dir
     new_cache_dir = _process_cache_path(cache_dir)
+
+    system_cache_dir = None
+    if (system_settings := system_settings_file()).exists():
+        system_cache_dir = dotenv_values(system_settings).get(
+            "lamindb_cache_path", None
+        )
+        system_cache_dir = (
+            Path(system_cache_dir) if system_cache_dir is not None else None
+        )
+
+    need_reset = False
     if new_cache_dir is None:
-        new_cache_dir = DEFAULT_CACHE_DIR
+        need_reset = True
+        new_cache_dir = (
+            DEFAULT_CACHE_DIR if system_cache_dir is None else system_cache_dir
+        )
+
     if new_cache_dir != old_cache_dir:
         if old_cache_dir.exists():
             shutil.copytree(old_cache_dir, new_cache_dir, dirs_exist_ok=True)
-            shutil.rmtree(old_cache_dir)
             logger.info(
-                "The current cache directory was moved to the specified location"
+                f"the current cache directory was moved to {new_cache_dir.as_posix()} "
             )
+            if old_cache_dir != system_cache_dir:
+                shutil.rmtree(old_cache_dir)
+                logger.info(
+                    f"cleared the old cache directory {old_cache_dir.as_posix()}"
+                )
+            else:
+                logger.info(
+                    f"didn't clear the system cache directory {system_cache_dir.as_posix()}, "
+                    "please clear it manually if you need"
+                )
         else:
             new_cache_dir.mkdir(parents=True, exist_ok=True)
-    new_cache_dir = new_cache_dir.resolve()
-    save_platform_user_storage_settings(new_cache_dir)
+        new_cache_dir = new_cache_dir.resolve()
+    save_platform_user_storage_settings(None if need_reset else new_cache_dir)
     settings._cache_dir = new_cache_dir

--- a/lamindb_setup/_cache.py
+++ b/lamindb_setup/_cache.py
@@ -21,9 +21,10 @@ def clear_cache_dir():
             raise e
 
     cache_dir = settings.cache_dir
-    shutil.rmtree(cache_dir)
-    cache_dir.mkdir()
-    logger.success("The cache directory was cleared.")
+    if cache_dir.exists():
+        shutil.rmtree(cache_dir)
+        cache_dir.mkdir()
+        logger.success("The cache directory was cleared.")
 
 
 def get_cache_dir():

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -8,11 +8,15 @@ from lamin_utils import logger
 from platformdirs import user_cache_dir
 
 from ._settings_load import (
+    load_cache_path_from_settings,
     load_instance_settings,
     load_or_create_user_settings,
-    load_storage_settings,
 )
-from ._settings_store import current_instance_settings_file, settings_dir
+from ._settings_store import (
+    current_instance_settings_file,
+    settings_dir,
+    system_settings_dir,
+)
 from .upath import LocalPathClasses, UPath
 
 if TYPE_CHECKING:
@@ -166,7 +170,7 @@ class SetupSettings:
         if "LAMIN_CACHE_DIR" in os.environ:
             cache_dir = UPath(os.environ["LAMIN_CACHE_DIR"])
         elif self._cache_dir is None:
-            cache_path = load_storage_settings().get("lamindb_cache_path", None)
+            cache_path = load_cache_path_from_settings()
             cache_dir = _process_cache_path(cache_path)
             if cache_dir is None:
                 cache_dir = DEFAULT_CACHE_DIR
@@ -199,10 +203,12 @@ class SetupSettings:
         # do not show current setting representation when building docs
         if "sphinx" in sys.modules:
             return object.__repr__(self)
-        repr = self.user.__repr__()
-        repr += f"\nAuto-connect in Python: {self.auto_connect}\n"
+        repr = f"Auto-connect in Python: {self.auto_connect}\n"
         repr += f"Private Django API: {self.private_django_api}\n"
         repr += f"Cache directory: {self.cache_dir.as_posix()}\n"
+        repr += f"User settings directory: {settings_dir.as_posix()}\n"
+        repr += f"System settings directory: {system_settings_dir.as_posix()}\n"
+        repr += self.user.__repr__() + "\n"
         if self._instance_exists:
             repr += self.instance.__repr__()
         else:

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 DEFAULT_CACHE_DIR = UPath(user_cache_dir(appname="lamindb", appauthor="laminlabs"))
 
 
-def _process_cache_path(cache_path: UPathStr | None):
+def _process_cache_path(cache_path: UPathStr | None) -> UPath | None:
     if cache_path is None or cache_path == "null":
         return None
     cache_dir = UPath(cache_path)

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -10,7 +10,7 @@ from platformdirs import user_cache_dir
 from ._settings_load import (
     load_instance_settings,
     load_or_create_user_settings,
-    load_user_storage_settings,
+    load_storage_settings,
 )
 from ._settings_store import current_instance_settings_file, settings_dir
 from .upath import LocalPathClasses, UPath
@@ -166,7 +166,7 @@ class SetupSettings:
         if "LAMIN_CACHE_DIR" in os.environ:
             cache_dir = UPath(os.environ["LAMIN_CACHE_DIR"])
         elif self._cache_dir is None:
-            cache_path = load_user_storage_settings().get("lamindb_cache_path", None)
+            cache_path = load_storage_settings().get("lamindb_cache_path", None)
             cache_dir = _process_cache_path(cache_path)
             if cache_dir is None:
                 cache_dir = DEFAULT_CACHE_DIR

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -4,8 +4,8 @@ import os
 import sys
 from typing import TYPE_CHECKING
 
-from appdirs import AppDirs
 from lamin_utils import logger
+from platformdirs import user_cache_dir
 
 from ._settings_load import (
     load_instance_settings,
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from lamindb_setup.types import UPathStr
 
 
-DEFAULT_CACHE_DIR = UPath(AppDirs("lamindb", "laminlabs").user_cache_dir)
+DEFAULT_CACHE_DIR = UPath(user_cache_dir(appname="lamindb", appauthor="laminlabs"))
 
 
 def _process_cache_path(cache_path: UPathStr | None):

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -10,7 +10,7 @@ from platformdirs import user_cache_dir
 from ._settings_load import (
     load_instance_settings,
     load_or_create_user_settings,
-    load_system_storage_settings,
+    load_user_storage_settings,
 )
 from ._settings_store import current_instance_settings_file, settings_dir
 from .upath import LocalPathClasses, UPath
@@ -166,7 +166,7 @@ class SetupSettings:
         if "LAMIN_CACHE_DIR" in os.environ:
             cache_dir = UPath(os.environ["LAMIN_CACHE_DIR"])
         elif self._cache_dir is None:
-            cache_path = load_system_storage_settings().get("lamindb_cache_path", None)
+            cache_path = load_user_storage_settings().get("lamindb_cache_path", None)
             cache_dir = _process_cache_path(cache_path)
             if cache_dir is None:
                 cache_dir = DEFAULT_CACHE_DIR

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -37,6 +37,8 @@ def _process_cache_path(cache_path: UPathStr | None):
         raise ValueError("cache dir should be a local path.")
     if cache_dir.exists() and not cache_dir.is_dir():
         raise ValueError("cache dir should be a directory.")
+    if not cache_dir.is_absolute():
+        raise ValueError("A path to the cache dir should be absolute.")
     return cache_dir
 
 

--- a/lamindb_setup/core/_settings_load.py
+++ b/lamindb_setup/core/_settings_load.py
@@ -28,7 +28,9 @@ def load_cache_path_from_settings(storage_settings: Path | None = None) -> Path 
     if storage_settings is None:
         paltform_user_storage_settings = platform_user_storage_settings_file()
         if paltform_user_storage_settings.exists():
-            cache_path = dotenv_values(storage_settings).get("lamindb_cache_path", None)
+            cache_path = dotenv_values(paltform_user_storage_settings).get(
+                "lamindb_cache_path", None
+            )
         else:
             cache_path = None
 

--- a/lamindb_setup/core/_settings_load.py
+++ b/lamindb_setup/core/_settings_load.py
@@ -25,12 +25,12 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def load_user_storage_settings(user_storage_settings: Path | None = None) -> dict:
-    if user_storage_settings is None:
-        user_storage_settings = user_storage_settings_file()
+def load_storage_settings(storage_settings: Path | None = None) -> dict:
+    if storage_settings is None:
+        storage_settings = user_storage_settings_file()
 
-    if user_storage_settings.exists():
-        return dotenv_values(user_storage_settings)
+    if storage_settings.exists():
+        return dotenv_values(storage_settings)
     else:
         return {}
 

--- a/lamindb_setup/core/_settings_load.py
+++ b/lamindb_setup/core/_settings_load.py
@@ -17,7 +17,7 @@ from ._settings_store import (
     UserSettingsStore,
     current_instance_settings_file,
     current_user_settings_file,
-    system_storage_settings_file,
+    user_storage_settings_file,
 )
 from ._settings_user import UserSettings
 
@@ -25,12 +25,12 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def load_system_storage_settings(system_storage_settings: Path | None = None) -> dict:
-    if system_storage_settings is None:
-        system_storage_settings = system_storage_settings_file()
+def load_user_storage_settings(user_storage_settings: Path | None = None) -> dict:
+    if user_storage_settings is None:
+        user_storage_settings = user_storage_settings_file()
 
-    if system_storage_settings.exists():
-        return dotenv_values(system_storage_settings)
+    if user_storage_settings.exists():
+        return dotenv_values(user_storage_settings)
     else:
         return {}
 

--- a/lamindb_setup/core/_settings_load.py
+++ b/lamindb_setup/core/_settings_load.py
@@ -26,20 +26,17 @@ from ._settings_user import UserSettings
 
 def load_cache_path_from_settings(storage_settings: Path | None = None) -> Path | None:
     if storage_settings is None:
-        system_settings = system_settings_file()
-        if system_settings.exists():
-            cache_path = dotenv_values(system_settings).get("lamindb_cache_path", None)
-        else:
-            cache_path = None
-
-        if cache_path in {None, "null"}:
-            storage_settings = platform_user_storage_settings_file()
+        paltform_user_storage_settings = platform_user_storage_settings_file()
+        if paltform_user_storage_settings.exists():
+            cache_path = dotenv_values(storage_settings).get("lamindb_cache_path", None)
+        if cache_path in {None, "null", ""}:
+            storage_settings = system_settings_file()
         else:
             return Path(cache_path)
 
     if storage_settings.exists():
         cache_path = dotenv_values(storage_settings).get("lamindb_cache_path", None)
-        return Path(cache_path) if cache_path not in {None, "null"} else None
+        return Path(cache_path) if cache_path not in {None, "null", ""} else None
     else:
         return None
 

--- a/lamindb_setup/core/_settings_load.py
+++ b/lamindb_setup/core/_settings_load.py
@@ -29,6 +29,9 @@ def load_cache_path_from_settings(storage_settings: Path | None = None) -> Path 
         paltform_user_storage_settings = platform_user_storage_settings_file()
         if paltform_user_storage_settings.exists():
             cache_path = dotenv_values(storage_settings).get("lamindb_cache_path", None)
+        else:
+            cache_path = None
+
         if cache_path in {None, "null", ""}:
             storage_settings = system_settings_file()
         else:

--- a/lamindb_setup/core/_settings_save.py
+++ b/lamindb_setup/core/_settings_save.py
@@ -83,7 +83,7 @@ def save_instance_settings(settings: Any, settings_file: Path):
     save_settings(settings, settings_file, type_hints, prefix)
 
 
-def save_user_storage_settings(
+def save_platform_user_storage_settings(
     cache_path: UPathStr | None, settings_file: UPathStr | None = None
 ):
     cache_path = "null" if cache_path is None else cache_path

--- a/lamindb_setup/core/_settings_save.py
+++ b/lamindb_setup/core/_settings_save.py
@@ -8,9 +8,9 @@ from ._settings_store import (
     InstanceSettingsStore,
     UserSettingsStore,
     current_user_settings_file,
-    system_storage_settings_file,
     user_settings_file_email,
     user_settings_file_handle,
+    user_storage_settings_file,
 )
 
 if TYPE_CHECKING:
@@ -83,13 +83,13 @@ def save_instance_settings(settings: Any, settings_file: Path):
     save_settings(settings, settings_file, type_hints, prefix)
 
 
-def save_system_storage_settings(
+def save_user_storage_settings(
     cache_path: UPathStr | None, settings_file: UPathStr | None = None
 ):
     cache_path = "null" if cache_path is None else cache_path
     if isinstance(cache_path, Path):  # also True for UPath
         cache_path = cache_path.as_posix()
     if settings_file is None:
-        settings_file = system_storage_settings_file()
+        settings_file = user_storage_settings_file()
     with open(settings_file, "w") as f:
         f.write(f"lamindb_cache_path={cache_path}")

--- a/lamindb_setup/core/_settings_save.py
+++ b/lamindb_setup/core/_settings_save.py
@@ -8,9 +8,9 @@ from ._settings_store import (
     InstanceSettingsStore,
     UserSettingsStore,
     current_user_settings_file,
+    platform_user_storage_settings_file,
     user_settings_file_email,
     user_settings_file_handle,
-    user_storage_settings_file,
 )
 
 if TYPE_CHECKING:
@@ -90,6 +90,6 @@ def save_user_storage_settings(
     if isinstance(cache_path, Path):  # also True for UPath
         cache_path = cache_path.as_posix()
     if settings_file is None:
-        settings_file = user_storage_settings_file()
+        settings_file = platform_user_storage_settings_file()
     with open(settings_file, "w") as f:
         f.write(f"lamindb_cache_path={cache_path}")

--- a/lamindb_setup/core/_settings_store.py
+++ b/lamindb_setup/core/_settings_store.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 from lamin_utils import logger
+from platformdirs import site_config_dir
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if "LAMIN_SETTINGS_DIR" in os.environ:
@@ -18,6 +19,9 @@ try:
     settings_dir.mkdir(parents=True, exist_ok=True)
 except Exception as e:
     logger.warning(f"Failed to create lamin settings directory at {settings_dir}: {e}")
+
+
+system_settings_dir = Path(site_config_dir(appname="lamindb", appauthor="laminlabs"))
 
 
 def get_settings_file_name_prefix():
@@ -49,8 +53,13 @@ def user_settings_file_handle(handle: str):
     return settings_dir / f"{get_settings_file_name_prefix()}user--{handle}.env"
 
 
-def user_storage_settings_file():
+# here user means the user directory on os, not a lamindb user
+def platform_user_storage_settings_file():
     return settings_dir / "storage.env"
+
+
+def system_settings_file():
+    return system_settings_dir / "system.env"
 
 
 class InstanceSettingsStore(BaseSettings):

--- a/lamindb_setup/core/_settings_store.py
+++ b/lamindb_setup/core/_settings_store.py
@@ -49,7 +49,7 @@ def user_settings_file_handle(handle: str):
     return settings_dir / f"{get_settings_file_name_prefix()}user--{handle}.env"
 
 
-def system_storage_settings_file():
+def user_storage_settings_file():
     return settings_dir / "storage.env"
 
 

--- a/lamindb_setup/core/_settings_store.py
+++ b/lamindb_setup/core/_settings_store.py
@@ -9,7 +9,7 @@ if "LAMIN_SETTINGS_DIR" in os.environ:
     # Needed when running with AWS Lambda, as only tmp/ directory has a write access
     settings_dir = Path(f"{os.environ['LAMIN_SETTINGS_DIR']}/.lamin")
 else:
-    # user_config_dir in appdirs is weird on MacOS!
+    # user_config_dir is weird on MacOS!
     # hence, let's take home/.lamin
     settings_dir = Path.home() / ".lamin"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "django>=5.1,<5.2",
     "dj_database_url>=1.3.0,<3.0.0",
     "pydantic-settings",
-    "appdirs<2.0.0",
+    "platformdirs<5.0.0",
     "requests",
     "universal_pathlib==0.2.6",  # is still experimental, need pinning
     "botocore<2.0.0",


### PR DESCRIPTION
Address https://github.com/laminlabs/pfizer-lamin-usage/issues/255

This allows to specify system wide configuration (only cache path for now) via `system.env` file in 
```python
platformdirs.site_config_dir(appname="lamindb", appauthor="laminlabs")
```
Specific folder is system-dependent and is shown in the output of `lamin info`.

Example of `system.env` file:
```
lamindb_cache_path=path/to/cache
```

The user specified cache path will take precedence this .