### PR TITLE
🩹 Various fixes for `connect`

### DIFF
--- a/lamindb_setup/__init__.py
+++ b/lamindb_setup/__init__.py
@@ -35,7 +35,7 @@ Modules & settings:
 
 """
 
-__version__ = "1.6.1"  # denote a release candidate for 0.1.0 with 0.1rc1
+__version__ = "1.6.2"  # denote a release candidate for 0.1.0 with 0.1rc1
 
 import os
 

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -293,8 +293,7 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
         load_from_isettings(isettings, user=_user, write_settings=_write_settings)
         if _reload_lamindb:
             importlib.reload(importlib.import_module("lamindb"))
-        else:
-            logger.important(f"connected lamindb: {isettings.slug}")
+        logger.important(f"connected lamindb: {isettings.slug}")
     except Exception as e:
         if isettings is not None:
             if _write_settings:


### PR DESCRIPTION
1. Always show "connected ..." logging message.
2. Disable updating the user on fine grained instances for now.