### PR TITLE
✨ Allow to specify a db token via the env variable `LAMIN_TEST_DB_TOKEN`

### DIFF
--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -473,6 +473,12 @@ def access_db(
     instance_id: UUID
     instance_slug: str
     instance_api_url: str | None
+    if (
+        "LAMIN_TEST_DB_TOKEN" in os.environ
+        and (env_db_token := os.environ["LAMIN_TEST_DB_TOKEN"]) != ""
+    ):
+        return env_db_token
+
     if isinstance(instance, InstanceSettings):
         instance_id = instance._id
         instance_slug = instance.slug

--- a/tests/hub-local/scripts/script-connect-fine-grained-access.py
+++ b/tests/hub-local/scripts/script-connect-fine-grained-access.py
@@ -51,3 +51,6 @@ with pytest.raises(RuntimeError):
     access_db(isettings)
 # check with providing access_token explicitly
 access_db(isettings, ln_setup.settings.user.access_token)
+# check specifying an env token via an env variable
+os.environ["LAMIN_TEST_DB_TOKEN"] = "test_db_token"
+assert access_db(isettings) == os.environ["LAMIN_TEST_DB_TOKEN"]


### PR DESCRIPTION
This is needed for local tests in `laminhub`.