### PR TITLE
🐛 Rework `get_storage_region()` to make it reliable and use it in `upath.to_url()` 

### DIFF
--- a/lamindb_setup/core/upath.py
+++ b/lamindb_setup/core/upath.py
@@ -840,6 +840,7 @@ def get_storage_region(path: UPathStr) -> str | None:
             if response.get("Error", {}).get("Code") == "404":
                 raise exc
     else:
+        upath = get_aws_options_manager()._path_inject_options(upath, {})
         try:
             response = upath.fs.call_s3("head_bucket", Bucket=bucket)
         except Exception as exc:

--- a/lamindb_setup/core/upath.py
+++ b/lamindb_setup/core/upath.py
@@ -687,12 +687,7 @@ def to_url(upath):
         raise ValueError("The provided UPath must be an S3 path.")
     key = "/".join(upath.parts[1:])
     bucket = upath.drive
-    if bucket == "scverse-spatial-eu-central-1":
-        region = "eu-central-1"
-    elif f"s3://{bucket}" not in HOSTED_BUCKETS:
-        region = get_storage_region(upath)
-    else:
-        region = bucket.replace("lamin_", "")
+    region = get_storage_region(upath)
     if region == "us-east-1":
         return f"https://{bucket}.s3.amazonaws.com/{key}"
     else:

--- a/tests/storage/test_storage_stats.py
+++ b/tests/storage/test_storage_stats.py
@@ -81,5 +81,12 @@ def test_get_stat_dir_cloud_hf():
 def test_get_storage_region():
     for region in HOSTED_REGIONS:
         assert get_storage_region(f"s3://lamin-{region}") == region
+    assert get_storage_region("s3://scverse-spatial-eu-central-1") == "eu-central-1"
+
     assert get_storage_region(UPath("s3://lamindata", endpoint_url=None)) == "us-east-1"
     assert get_storage_region("s3://lamindata/?endpoint_url=") == "us-east-1"
+    # private bucket
+    assert (
+        get_storage_region(UPath("s3://lamindb-setup-private-bucket/some-folder"))
+        == "us-east-1"
+    )

--- a/tests/storage/test_to_url.py
+++ b/tests/storage/test_to_url.py
@@ -12,7 +12,9 @@ def test_to_url():
     )
     # private bucket
     assert (
-        ln_setup.core.upath.create_path("s3://lamindb-setup-private-bucket/test-folder")
+        ln_setup.core.upath.create_path(
+            "s3://lamindb-setup-private-bucket/test-folder"
+        ).to_url()
         == "https://lamindb-setup-private-bucket.s3.amazonaws.com/test-folder"
     )
     # eu-central-1 / AWS Dev

--- a/tests/storage/test_to_url.py
+++ b/tests/storage/test_to_url.py
@@ -11,11 +11,10 @@ def test_to_url():
         == "https://lamindata.s3.amazonaws.com/test-folder"
     )
     # private bucket
-    # next PR
-    # assert (
-    #     ln_setup.core.upath.create_path("s3://lamindb-setup-private-bucket/test-folder")
-    #     == "https://lamindb-setup-private-bucket.s3.amazonaws.com/test-folder"
-    # )
+    assert (
+        ln_setup.core.upath.create_path("s3://lamindb-setup-private-bucket/test-folder")
+        == "https://lamindb-setup-private-bucket.s3.amazonaws.com/test-folder"
+    )
     # eu-central-1 / AWS Dev
     assert (
         ln_setup.core.upath.create_path("s3://lamindata-eu/test-folder").to_url()

--- a/tests/storage/test_to_url.py
+++ b/tests/storage/test_to_url.py
@@ -27,5 +27,5 @@ def test_to_url():
         ln_setup.core.upath.create_path(
             "s3://lamin-eu-central-1/9fm7UN13/test-folder"
         ).to_url()
-        == "https://lamin-eu-central-1.s3-lamin-eu-central-1.amazonaws.com/9fm7UN13/test-folder"
+        == "https://lamin-eu-central-1.s3-eu-central-1.amazonaws.com/9fm7UN13/test-folder"
     )


### PR DESCRIPTION
Now (monkey-patched) `upath.to_url()` fails if `head_bucket` is not permitted, this PR fixes the problem.

Also there was a bug in `upath.to_url()` for hosted buckets.