### PR TITLE
👔 Rework `update_db_using_local` to always use hub db connection if available

### DIFF
--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -15,10 +15,7 @@ from ._init_instance import (
 )
 from ._silence_loggers import silence_loggers
 from .core._hub_core import connect_instance_hub
-from .core._hub_utils import (
-    LaminDsn,
-    LaminDsnModel,
-)
+from .core._hub_utils import LaminDsnModel
 from .core._settings import settings
 from .core._settings_instance import InstanceSettings
 from .core._settings_load import load_instance_settings

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -67,16 +67,15 @@ def update_db_using_local(
         if db is not None:
             # use only the provided db if it is set
             db_updated = db
+        elif (db_env := os.getenv("LAMINDB_INSTANCE_DB")) is not None:
+            logger.important("loading db URL from env variable LAMINDB_INSTANCE_DB")
+            # read directly from the environment
+            db_updated = db_env
         else:
             db_hub = hub_instance_result["db"]
             db_dsn_hub = LaminDsnModel(db=db_hub)
-            # read directly from the environment
-            db_env = os.getenv("LAMINDB_INSTANCE_DB")
-            if db_env is not None:
-                logger.important("loading db URL from env variable LAMINDB_INSTANCE_DB")
-                db_updated = db_env
             # read from a cached settings file in case the hub result is inexistent
-            elif db_dsn_hub.db.user in {None, "none"} and settings_file.exists():
+            if db_dsn_hub.db.user in {None, "none"} and settings_file.exists():
                 isettings = load_instance_settings(settings_file)
                 db_updated = isettings.db
             else:

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -78,8 +78,7 @@ def update_db_using_local(
             if db_env is not None:
                 logger.important("loading db URL from env variable LAMINDB_INSTANCE_DB")
                 db_updated = db_env
-            # read from a cached settings file in case the hub result is only
-            # read level or inexistent
+            # read from a cached settings file in case the hub result is inexistent
             elif db_dsn_hub.db.user in {None, "none"} and settings_file.exists():
                 isettings = load_instance_settings(settings_file)
                 db_updated = isettings.db


### PR DESCRIPTION
Change the logic of determining the correct db connection.

- Always use hub db connection over local if it is present.
- Do not error if hub db connection string is different from the local connection string, just use hub.