### PR TITLE
♻️ Simplify `init_storage()`

### DIFF
--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -311,6 +311,10 @@ def init(
             created_by=user__uuid,
             access_token=access_token,
         )
+        if register_on_hub and not ssettings.is_on_hub:
+            raise InstanceNotCreated(
+                "Unable to create the instance because failed to register the storage."
+            )
         isettings._storage = ssettings
         validate_sqlite_state(isettings)
         # why call it here if it is also called in load_from_isettings?

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -285,24 +285,12 @@ def init(
         )
         if instance_state == "connected":
             return None
-        prevent_register_hub = is_local_db_url(db) if db is not None else False
-        ssettings, _ = init_storage(
-            storage,
-            instance_id=instance_id,
-            instance_slug=f"{user_handle}/{name_str}",
-            init_instance=True,
-            prevent_register_hub=prevent_register_hub,
-            created_by=user__uuid,
-            access_token=access_token,
-        )
         isettings = InstanceSettings(
             id=instance_id,  # type: ignore
             owner=user_handle,
             name=name_str,
-            storage=ssettings,
             db=db,
             modules=modules,
-            uid=ssettings.uid,
             # to lock passed user in isettings._cloud_sqlite_locker.lock()
             _locker_user=_user,  # only has effect if cloud sqlite
         )
@@ -320,6 +308,17 @@ def init(
             init_instance_hub(
                 isettings, account_id=user__uuid, access_token=access_token
             )
+        prevent_register_hub = is_local_db_url(db) if db is not None else False
+        ssettings, _ = init_storage(
+            storage,
+            instance_id=instance_id,
+            instance_slug=f"{user_handle}/{name_str}",
+            init_instance=True,
+            prevent_register_hub=prevent_register_hub,
+            created_by=user__uuid,
+            access_token=access_token,
+        )
+        isettings._storage = ssettings
         validate_sqlite_state(isettings)
         # why call it here if it is also called in load_from_isettings?
         isettings._persist(write_to_disk=_write_settings)

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -347,16 +347,10 @@ def init(
                 delete_by_isettings(isettings)
             else:
                 settings._instance_settings = None
-        if (
-            ssettings is not None
-            and (user_handle != "anonymous" or access_token is not None)
-            and ssettings.is_on_hub
-        ):
-            delete_storage_record(ssettings, access_token=access_token)  # type: ignore
-        if isettings is not None:
-            if (
-                user_handle != "anonymous" or access_token is not None
-            ) and isettings.is_on_hub:
+        if user_handle != "anonymous" or access_token is not None:
+            if ssettings is not None and ssettings.is_on_hub:
+                delete_storage_record(ssettings, access_token=access_token)
+            if isettings is not None and isettings.is_on_hub:
                 delete_instance_record(isettings._id, access_token=access_token)
         raise e
     return None

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -311,11 +311,11 @@ def init(
             created_by=user__uuid,
             access_token=access_token,
         )
+        isettings._storage = ssettings
         if register_on_hub and not ssettings.is_on_hub:
             raise InstanceNotCreated(
                 "Unable to create the instance because failed to register the storage."
             )
-        isettings._storage = ssettings
         validate_sqlite_state(isettings)
         # why call it here if it is also called in load_from_isettings?
         isettings._persist(write_to_disk=_write_settings)

--- a/lamindb_setup/_register_instance.py
+++ b/lamindb_setup/_register_instance.py
@@ -23,7 +23,7 @@ def register(_test: bool = False):
         # because django isn't up, we can't get it from the database
         ssettings._uid = base62(12)
     init_instance_hub(isettings)
-    init_storage_hub(ssettings)
+    init_storage_hub(ssettings, is_default=True)
     isettings._is_on_hub = True
     isettings._persist()
     if isettings.dialect != "sqlite" and not _test:

--- a/lamindb_setup/_register_instance.py
+++ b/lamindb_setup/_register_instance.py
@@ -21,12 +21,9 @@ def register(_test: bool = False):
     ssettings = settings.instance.storage
     if ssettings._uid is None and _test:
         # because django isn't up, we can't get it from the database
-        ssettings._uid = base62(8)
-    # cannot yet populate the instance id here
-    ssettings._instance_id = None
-    # flag auto_populate_instance can be removed once FK migration is over
-    init_storage_hub(ssettings, auto_populate_instance=False)
+        ssettings._uid = base62(12)
     init_instance_hub(isettings)
+    init_storage_hub(ssettings)
     isettings._is_on_hub = True
     isettings._persist()
     if isettings.dialect != "sqlite" and not _test:

--- a/lamindb_setup/_set_managed_storage.py
+++ b/lamindb_setup/_set_managed_storage.py
@@ -49,7 +49,6 @@ def set_managed_storage(root: UPathStr, host: str | None = None, **fs_kwargs):
         instance_id=settings.instance._id,
         instance_slug=settings.instance.slug,
         register_hub=settings.instance.is_on_hub,
-        prevent_register_hub=not settings.instance.is_on_hub,
         region=host,
     )
     if ssettings._instance_id is None:

--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -147,7 +147,6 @@ def select_storage_or_parent(path: str, access_token: str | None = None) -> dict
 
 def init_storage_hub(
     ssettings: StorageSettings,
-    auto_populate_instance: bool = True,
     created_by: UUID | None = None,
     access_token: str | None = None,
     prevent_creation: bool = False,
@@ -157,7 +156,6 @@ def init_storage_hub(
         return call_with_fallback_auth(
             _init_storage_hub,
             ssettings=ssettings,
-            auto_populate_instance=auto_populate_instance,
             created_by=created_by,
             access_token=access_token,
             prevent_creation=prevent_creation,
@@ -175,7 +173,6 @@ def init_storage_hub(
 def _init_storage_hub(
     client: Client,
     ssettings: StorageSettings,
-    auto_populate_instance: bool,
     created_by: UUID | None = None,
     prevent_creation: bool = False,
 ) -> Literal["hub-record-retrieved", "hub-record-created", "hub-record-not-created"]:
@@ -193,19 +190,13 @@ def _init_storage_hub(
         id = uuid.uuid5(uuid.NAMESPACE_URL, root)
     else:
         id = uuid.uuid4()
-    if (
-        ssettings._instance_id is None
-        and settings._instance_exists
-        and auto_populate_instance
-    ):
+    if ssettings._instance_id is None and settings._instance_exists:
         logger.warning(
             f"will manage storage location {ssettings.root_as_str} with instance {settings.instance.slug}"
         )
         ssettings._instance_id = settings.instance._id
     instance_id_hex = (
-        ssettings._instance_id.hex
-        if (ssettings._instance_id is not None and auto_populate_instance)
-        else None
+        ssettings._instance_id.hex if ssettings._instance_id is not None else None
     )
     fields = {
         "id": id.hex,

--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -198,9 +198,7 @@ def _init_storage_hub(
             f"will manage storage location {ssettings.root_as_str} with instance {settings.instance.slug}"
         )
         ssettings._instance_id = settings.instance._id
-    instance_id_hex = (
-        ssettings._instance_id.hex if ssettings._instance_id is not None else None
-    )
+    assert ssettings._instance_id is not None, "connect to an instance"
     fields = {
         "id": id.hex,
         "lnid": ssettings.uid,
@@ -208,7 +206,7 @@ def _init_storage_hub(
         "root": root,
         "region": ssettings.region,
         "type": ssettings.type,
-        "instance_id": instance_id_hex,
+        "instance_id": ssettings._instance_id.hex,
         # the empty string is important as we want the user flow to be through LaminHub
         # if this errors with unique constraint error, the user has to update
         # the description in LaminHub

--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -150,6 +150,7 @@ def init_storage_hub(
     created_by: UUID | None = None,
     access_token: str | None = None,
     prevent_creation: bool = False,
+    is_default: bool = False,
 ) -> Literal["hub-record-retrieved", "hub-record-created", "hub-record-not-created"]:
     """Creates or retrieves an existing storage record from the hub."""
     if settings.user.handle != "anonymous" or access_token is not None:
@@ -159,6 +160,7 @@ def init_storage_hub(
             created_by=created_by,
             access_token=access_token,
             prevent_creation=prevent_creation,
+            is_default=is_default,
         )
     else:
         storage_exists = call_with_fallback(
@@ -175,6 +177,7 @@ def _init_storage_hub(
     ssettings: StorageSettings,
     created_by: UUID | None = None,
     prevent_creation: bool = False,
+    is_default: bool = False,
 ) -> Literal["hub-record-retrieved", "hub-record-created", "hub-record-not-created"]:
     from lamindb_setup import settings
 
@@ -210,6 +213,7 @@ def _init_storage_hub(
         # if this errors with unique constraint error, the user has to update
         # the description in LaminHub
         "description": "",
+        "is_default": is_default,
     }
     # TODO: add error message for violated unique constraint
     # on root & description

--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -351,9 +351,6 @@ def _init_instance_hub(
     except APIError:
         logger.warning(f"instance already existed at: https://lamin.ai/{slug}")
         return None
-    client.table("storage").update(
-        {"instance_id": isettings._id.hex, "is_default": True}
-    ).eq("id", isettings.storage._uuid.hex).execute()  # type: ignore
     if isettings.dialect != "sqlite" and isettings.is_remote:
         logger.important(f"go to: https://lamin.ai/{slug}")
 

--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -58,7 +58,7 @@ class InstanceSettings:
         id: UUID,  # instance id/uuid
         owner: str,  # owner handle
         name: str,  # instance name
-        storage: StorageSettings | None,  # storage location
+        storage: StorageSettings | None = None,  # storage location
         keep_artifacts_local: bool = False,  # default to local storage
         db: str | None = None,  # DB URI
         modules: str | None = None,  # comma-separated string of module names

--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -60,7 +60,6 @@ class InstanceSettings:
         name: str,  # instance name
         storage: StorageSettings | None,  # storage location
         keep_artifacts_local: bool = False,  # default to local storage
-        uid: str | None = None,  # instance uid/lnid
         db: str | None = None,  # DB URI
         modules: str | None = None,  # comma-separated string of module names
         git_repo: str | None = None,  # a git repo URL
@@ -76,7 +75,6 @@ class InstanceSettings:
         self._id_: UUID = id
         self._owner: str = owner
         self._name: str = name
-        self._uid: str | None = uid
         self._storage: StorageSettings | None = storage
         validate_db_arg(db)
         self._db: str | None = db

--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -55,7 +55,8 @@ def is_local_db_url(db_url: str) -> bool:
 def check_is_instance_remote(root: UPathStr, db: str | None) -> bool:
     # returns True for cloud SQLite
     # and remote postgres
-    if get_storage_type(str(root)) == "local":
+    root_str = str(root)
+    if not root_str.startswith("create-s3") and get_storage_type(root_str) == "local":
         return False
 
     if db is not None and is_local_db_url(db):

--- a/lamindb_setup/core/_settings_storage.py
+++ b/lamindb_setup/core/_settings_storage.py
@@ -144,9 +144,6 @@ def init_storage(
     )
     # this retrieves the storage record if it exists already in the hub
     # and updates uid and instance_id in ssettings
-    register_hub = (
-        register_hub or ssettings.type_is_cloud
-    )  # default to registering cloud storage
     if register_hub and not ssettings.type_is_cloud and ssettings.host is None:
         raise ValueError(
             "`host` must be set for local storage locations that are registered on the hub"

--- a/lamindb_setup/core/_settings_storage.py
+++ b/lamindb_setup/core/_settings_storage.py
@@ -92,7 +92,6 @@ def init_storage(
     instance_id: UUID,
     instance_slug: str,
     register_hub: bool | None = None,
-    prevent_register_hub: bool = False,
     init_instance: bool = False,
     created_by: UUID | None = None,
     access_token: str | None = None,
@@ -157,7 +156,7 @@ def init_storage(
         auto_populate_instance=not init_instance,
         created_by=created_by,
         access_token=access_token,
-        prevent_creation=prevent_register_hub or not register_hub,
+        prevent_creation=not register_hub,
     )
     # we check the write access here if the storage record has not been retrieved from the hub
     if hub_record_status != "hub-record-retrieved":

--- a/lamindb_setup/core/_settings_storage.py
+++ b/lamindb_setup/core/_settings_storage.py
@@ -153,7 +153,6 @@ def init_storage(
         )
     hub_record_status = init_storage_hub(
         ssettings,
-        auto_populate_instance=not init_instance,
         created_by=created_by,
         access_token=access_token,
         prevent_creation=not register_hub,

--- a/lamindb_setup/core/_settings_storage.py
+++ b/lamindb_setup/core/_settings_storage.py
@@ -156,6 +156,7 @@ def init_storage(
         created_by=created_by,
         access_token=access_token,
         prevent_creation=not register_hub,
+        is_default=init_instance,
     )
     # we check the write access here if the storage record has not been retrieved from the hub
     if hub_record_status != "hub-record-retrieved":

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ def lint(session: nox.Session) -> None:
     ["hub-local", "hub-prod", "hub-cloud", "storage", "docs"],
 )
 def install(session: nox.Session, group: str) -> None:
-    no_deps_packages = "git+https://github.com/laminlabs/lamindb git+https://github.com/laminlabs/wetlab git+https://github.com/laminlabs/lamin-cli"
+    no_deps_packages = "git+https://github.com/laminlabs/lamindb@simplifystorage git+https://github.com/laminlabs/wetlab git+https://github.com/laminlabs/lamin-cli"
     modules_deps = f"""uv pip install --system --no-deps {no_deps_packages}
 uv pip install --system git+https://github.com/laminlabs/bionty
 """

--- a/tests/hub-cloud/test_init_instance.py
+++ b/tests/hub-cloud/test_init_instance.py
@@ -68,9 +68,10 @@ def test_init_instance_postgres_default_name(get_hub_client):
     ln_setup.register(_test=True)
     assert ln_setup.settings.instance.slug == "testuser2/pgtest"
     # and check
-    instance, storage = _connect_instance_hub(
-        owner="testuser2", name=instance_name, client=hub
-    )
+    result = _connect_instance_hub(owner="testuser2", name=instance_name, client=hub)
+    if not isinstance(result, tuple):
+        raise TypeError(f"Expected tuple, got: {result}")
+    instance, _ = result  # no checks on storage
     # hub checks
     assert instance["db"].startswith("postgresql://none:none")
     assert instance["name"] == instance_name

--- a/tests/hub-local/test_all.py
+++ b/tests/hub-local/test_all.py
@@ -144,6 +144,7 @@ def create_myinstance(create_testadmin1_session):  # -> Dict
         instance_id=instance_id,
         instance_slug=instance_slug,
         init_instance=True,
+        register_hub=True,
     )[0]
     isettings._storage = storage
     # test loading it
@@ -395,6 +396,7 @@ def test_init_storage_with_non_existing_bucket(
                 instance_id=UUID(create_myinstance["id"]),
                 instance_slug=f"testadmin1/{create_myinstance['id']}",
                 init_instance=True,
+                register_hub=True,
             )[0]
         )
     assert error.exconly().endswith("Not Found")
@@ -407,6 +409,7 @@ def test_init_storage_incorrect_protocol(create_myinstance):
             instance_id=create_myinstance["id"],
             instance_slug=f"testadmin1/{create_myinstance['id']}",
             init_instance=True,
+            register_hub=True,
         )
     assert "Protocol incorrect-protocol is not supported" in error.exconly()
 

--- a/tests/hub-local/test_all.py
+++ b/tests/hub-local/test_all.py
@@ -136,16 +136,16 @@ def create_myinstance(create_testadmin1_session):  # -> Dict
         id=instance_id,
         owner=usettings.handle,
         name=instance_name,
-        # cannot yet pass instance_id here as it does not yet exist
-        storage=init_storage_base(
-            "s3://lamindb-ci/myinstance",
-            instance_id=instance_id,
-            instance_slug=instance_slug,
-            init_instance=True,
-        )[0],
         db=db_str,
     )
     init_instance_hub(isettings)
+    storage = init_storage_base(
+        "s3://lamindb-ci/myinstance",
+        instance_id=instance_id,
+        instance_slug=instance_slug,
+        init_instance=True,
+    )[0]
+    isettings._storage = storage
     # test loading it
     with pytest.raises(PermissionError) as error:
         ln_setup.connect("testadmin1/myinstance", _test=True)

--- a/tests/hub-local/test_all.py
+++ b/tests/hub-local/test_all.py
@@ -392,7 +392,7 @@ def test_init_storage_with_non_existing_bucket(
         init_storage_hub(
             ssettings=init_storage_base(
                 root="s3://non_existing_storage_root",
-                instance_id=create_myinstance["id"],
+                instance_id=UUID(create_myinstance["id"]),
                 instance_slug=f"testadmin1/{create_myinstance['id']}",
                 init_instance=True,
             )[0]


### PR DESCRIPTION
This PR simplifies `init_storage()` and related parts of the code.

The main reason for why simplification is possible is because the order of creation of hub instance and storage records can be reverted; the previous order still dates back to the originally inverted foreign key relationships between instance and storage in the hub.

This will also marginally speed up instance creation (one network request less).

The PR prepares passing a `space_id` argument to `init_storage_hub()`, which will be natural and parallel to how `instance_id` is now handled. Prior to this PR, due to the complicated order, several conditionals had to be met. Now, `instance_id` is always passed when creating a storage record on the hub.

Comes with:

- https://github.com/laminlabs/lamindb/pull/3023