### PR TITLE
✨ Add `space_uuid` argument to `init_storage()`

### DIFF
--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -93,6 +93,18 @@ def _get_storage_records_for_instance(
     return response.data
 
 
+def select_space(space_lnid: str) -> dict | None:
+    return call_with_fallback_auth(
+        _select_space,
+        space_lnid=space_lnid,
+    )
+
+
+def _select_space(space_lnid: str, client: Client) -> dict | None:
+    response = client.table("space").select("*").eq("lnid", space_lnid).execute()
+    return response.data[0] if response.data else None
+
+
 def _select_storage(
     ssettings: StorageSettings, update_uid: bool, client: Client
 ) -> bool:

--- a/lamindb_setup/core/_settings_storage.py
+++ b/lamindb_setup/core/_settings_storage.py
@@ -96,7 +96,7 @@ def init_storage(
     created_by: UUID | None = None,
     access_token: str | None = None,
     region: str | None = None,
-    space_id: UUID | None = None,
+    space_uuid: UUID | None = None,
 ) -> tuple[
     StorageSettings,
     Literal["hub-record-not-created", "hub-record-retrieved", "hub-record-created"],
@@ -155,7 +155,7 @@ def init_storage(
         access_token=access_token,
         prevent_creation=not register_hub,
         is_default=init_instance,
-        space_id=space_id,
+        space_id=space_uuid,
     )
     # we check the write access here if the storage record has not been retrieved from the hub
     if hub_record_status != "hub-record-retrieved":

--- a/lamindb_setup/core/_settings_storage.py
+++ b/lamindb_setup/core/_settings_storage.py
@@ -96,6 +96,7 @@ def init_storage(
     created_by: UUID | None = None,
     access_token: str | None = None,
     region: str | None = None,
+    space_id: UUID | None = None,
 ) -> tuple[
     StorageSettings,
     Literal["hub-record-not-created", "hub-record-retrieved", "hub-record-created"],
@@ -154,6 +155,7 @@ def init_storage(
         access_token=access_token,
         prevent_creation=not register_hub,
         is_default=init_instance,
+        space_id=space_id,
     )
     # we check the write access here if the storage record has not been retrieved from the hub
     if hub_record_status != "hub-record-retrieved":


### PR DESCRIPTION
I want to keep dealing with spaces as simple as possible in lamindb.

The simplest way would be to not even store the space association of a storage location in the hub db, but just in the instance db. But we have the storage and space tables in the hub db already it'd seem like a departure from the idea of keeping track of key metadata in the hub db.

Hence, this PR merely enables populating the space table in the hub db.

Notion page: https://www.notion.so/laminlabs/Enable-fine-grained-access-management-for-the-storage-layer-2392aeaa55e180ed85f8dd21cff41c70