### PR TITLE
🚸 More specific hint & comments about re-connecting lamindb instances in presence of function-scoped imports

### DIFF
--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -330,7 +330,8 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
                             )
                         else:
                             logger.important_hint(
-                                "switching the default lamindb instance might produce unexpected side effects if locally-scoped imports of registries are used"
+                                "switching the default lamindb instance might produce unexpected side effects with function-scoped imports: "
+                                "please import lamindb at the module level instead of inside functions"
                             )
                     reset_django()
             elif (


### PR DESCRIPTION
There seems to be no way to enable re-connecting django when the user uses local imports inside functions:

```python
def my_function():
    import lamindb as ln

    print("class id", id(ln.Transform))
    ln.connect("testdb")
    print("class id", id(ln.Transform))  # this still holds the old class reference, there is no way to update it 
    import lamindb as ln
    print("class id", id(ln.Transform))  # this now holds the updated reference
    ln.Transform.to_dataframe()

my_function()
```

<details><summary>Output</summary>
<p>

```
% python test_script.py
! not connected, call: ln.connect('account/name')
class id 5646710032
→ connected lamindb: falexwolf/testdb
class id 5646710032
class id 5682282832
```

</p>
</details> 


This works as expected:
```python
import lamindb as ln
def my_function():
    print("class id", id(ln.Transform))
    ln.connect("testdb")
    print("class id", id(ln.Transform))  # this now holds the updated reference
    ln.Transform.to_dataframe()

my_function()
```

<details><summary>Output</summary>
<p>

```
% python test_script.py
! not connected, call: ln.connect('account/name')
class id 5188732448
→ connected lamindb: falexwolf/testdb
class id 5230074416
```

</p>
</details> 

So, we now print a hint that the second pattern should be followed.

```
switching the default lamindb instance might produce unexpected side effects with function-scoped imports: 
please import lamindb at the module level instead of inside functions
```

Slack thread: https://laminlabs.slack.com/archives/C04FPE8V01W/p1757320976527249