### PR TITLE
⬇️ Downgrade `pytest-cov` to <7.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "python-dotenv",
     "nox",
     "pytest>=6.0",
-    "pytest-cov",
+    "pytest-cov<7.0.0",
     "pytest-xdist",
     "nbproject-test>=0.4.3",
     "pandas",


### PR DESCRIPTION
For now, `pytest-cov==7.0.0` doesn't count coverage from subprocesses anymore. For newer versions this should be resolved with `coverage` subprocess patch.