### PR TITLE
🗃️ Disable `gssencmode` for postgres

### DIFF
--- a/lamindb_setup/core/django.py
+++ b/lamindb_setup/core/django.py
@@ -168,7 +168,10 @@ def setup_django(
                 ssl_require = False
             else:
                 ssl_require = not is_local_db_url(instance_db)
-            options = {"connect_timeout": os.getenv("PGCONNECT_TIMEOUT", 20)}
+            options = {
+                "connect_timeout": os.getenv("PGCONNECT_TIMEOUT", 20),
+                "gssencmode": "disable",
+            }
         else:
             ssl_require = False
             options = {}


### PR DESCRIPTION
Avoid 
`OperationalError: connection to server at "aws-0-us-east-1.pooler.supabase.com" (44.216.29.125), port 6543 failed: received invalid response to GSSAPI negotiation: S`

