### PR TITLE
🏗️ Invalidate instance cache after migration

### DIFF
--- a/lamindb_setup/_migrate.py
+++ b/lamindb_setup/_migrate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import requests  # type: ignore
 from django.db import connection
 from django.db.migrations.loader import MigrationLoader
 from lamin_utils import logger
@@ -142,6 +143,11 @@ class migrate:
             logger.important(f"updating lamindb version in hub: {lamindb.__version__}")
             if settings.instance.dialect != "sqlite":
                 update_schema_in_hub()
+                requests.delete(
+                    f"{settings.instance._api_url}/cache/instances/{settings.instance._id.hex}",
+                    headers={"Authorization": f"Bearer {settings.user.access_token}"},
+                )
+
             call_with_fallback_auth(
                 update_instance,
                 instance_id=settings.instance._id.hex,

--- a/lamindb_setup/_migrate.py
+++ b/lamindb_setup/_migrate.py
@@ -143,11 +143,13 @@ class migrate:
             logger.important(f"updating lamindb version in hub: {lamindb.__version__}")
             if settings.instance.dialect != "sqlite":
                 update_schema_in_hub()
+                logger.warning(
+                    "clearing instance cache in hub; if this fails, re-run with latest lamindb version"
+                )
                 requests.delete(
-                    f"{settings.instance._api_url}/cache/instances/{settings.instance._id.hex}",
+                    f"{settings.instance.api_url}/cache/instances/{settings.instance._id.hex}",
                     headers={"Authorization": f"Bearer {settings.user.access_token}"},
                 )
-
             call_with_fallback_auth(
                 update_instance,
                 instance_id=settings.instance._id.hex,


### PR DESCRIPTION
This is now necessary because we dropped the `schema_id` arg from the hub REST API.