### PR TITLE
🐛  Use `httpx_retries` to retry on all timeouts and connection errors for http requests

### DIFF
--- a/lamindb_setup/_migrate.py
+++ b/lamindb_setup/_migrate.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import requests  # type: ignore
+import httpx
 from django.db import connection
 from django.db.migrations.loader import MigrationLoader
 from lamin_utils import logger
@@ -146,7 +146,7 @@ class migrate:
                 logger.warning(
                     "clearing instance cache in hub; if this fails, re-run with latest lamindb version"
                 )
-                requests.delete(
+                httpx.delete(
                     f"{settings.instance.api_url}/cache/instances/{settings.instance._id.hex}",
                     headers={"Authorization": f"Bearer {settings.user.access_token}"},
                 )

--- a/lamindb_setup/core/_aws_storage.py
+++ b/lamindb_setup/core/_aws_storage.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
+import httpx
 from lamin_utils import logger
 
 
 def get_location(ip="ipinfo.io"):
-    import requests  # type: ignore
-
-    response = requests.get(f"http://{ip}/json").json()
+    response = httpx.get(f"http://{ip}/json").json()
     loc = response["loc"].split(",")
     return {"latitude": float(loc[0]), "longitude": float(loc[1])}
 

--- a/lamindb_setup/core/_hub_client.py
+++ b/lamindb_setup/core/_hub_client.py
@@ -148,17 +148,18 @@ def call_with_fallback_auth(
     access_token = kwargs.pop("access_token", None)
 
     if access_token is not None:
+        client = None
         try:
             client = connect_hub_with_auth(access_token=access_token)
             result = callable(**kwargs, client=client)
         finally:
-            try:
+            if client is not None:
                 client.auth.sign_out(options={"scope": "local"})
-            except NameError:
-                pass
+
         return result
 
     for renew_token, fallback_env in [(False, False), (True, False), (False, True)]:
+        client = None
         try:
             client = connect_hub_with_auth(
                 renew_token=renew_token, fallback_env=fallback_env
@@ -179,10 +180,9 @@ def call_with_fallback_auth(
             if fallback_env:
                 raise e
         finally:
-            try:
+            if client is not None:
                 client.auth.sign_out(options={"scope": "local"})
-            except NameError:
-                pass
+
     return result
 
 
@@ -191,6 +191,7 @@ def call_with_fallback(
     **kwargs,
 ):
     for fallback_env in [False, True]:
+        client = None
         try:
             client = connect_hub(fallback_env=fallback_env)
             result = callable(**kwargs, client=client)
@@ -199,11 +200,9 @@ def call_with_fallback(
             if fallback_env:
                 raise e
         finally:
-            try:
+            if client is not None:
                 # in case there was sign in
                 client.auth.sign_out(options={"scope": "local"})
-            except NameError:
-                pass
     return result
 
 

--- a/lamindb_setup/core/_hub_client.py
+++ b/lamindb_setup/core/_hub_client.py
@@ -63,7 +63,7 @@ class Environment:
         self.supabase_anon_key: str = key
 
 
-DEFAULT_TIMEOUT = 10
+DEFAULT_TIMEOUT = 12
 
 
 # runs ~0.5s

--- a/lamindb_setup/core/_hub_core.py
+++ b/lamindb_setup/core/_hub_core.py
@@ -456,7 +456,7 @@ def _connect_instance_hub(
                 )
     # no instance found, check why is that
     if response == b"{}":
-        # try the via single requests, will take more time
+        # try via separate requests, will take more time
         account = select_account_by_handle(owner, client)
         if account is None:
             return "account-not-exists"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "dj_database_url>=1.3.0,<3.0.0",
     "pydantic-settings",
     "platformdirs<5.0.0",
-    "requests",
+    "httpx_retries",
     "universal_pathlib==0.2.6",  # is still experimental, need pinning
     "botocore<2.0.0",
     "supabase>=2.8.1,<=2.15.0", # from 2.8.1 has correct lower bounds on gotrue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "httpx_retries<5.0.0",
     "universal_pathlib==0.2.6",  # is still experimental, need pinning
     "botocore<2.0.0",
-    "supabase>=2.8.1,<=2.15.0", # from 2.8.1 has correct lower bounds on gotrue
+    "supabase>=2.8.1,<=2.16.0", # from 2.8.1 has correct lower bounds on gotrue
     "gotrue<=2.12.0", # supabase doesn't have this upper bound
     "storage3!=0.11.2; python_version < '3.11'", # 0.11.2 breaks python 3.10 through usage of new types
     "pyjwt<3.0.0", # needed to decode jwt for sign in with the new api key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pydantic-settings",
     "platformdirs<5.0.0",
     "httpx_retries<5.0.0",
+    "requests", # keep for now for other packages (bionty etc)
     "universal_pathlib==0.2.6",  # is still experimental, need pinning
     "botocore<2.0.0",
     "supabase>=2.8.1,<=2.16.0", # from 2.8.1 has correct lower bounds on gotrue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "dj_database_url>=1.3.0,<3.0.0",
     "pydantic-settings",
     "platformdirs<5.0.0",
-    "httpx_retries",
+    "httpx_retries<5.0.0",
     "universal_pathlib==0.2.6",  # is still experimental, need pinning
     "botocore<2.0.0",
     "supabase>=2.8.1,<=2.15.0", # from 2.8.1 has correct lower bounds on gotrue


### PR DESCRIPTION
I realize now that before it was ignoring read timeouts completely.