### PR TITLE
🚸 Allow `init()` after another instance was connected

### DIFF
--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -270,10 +270,6 @@ def init(
         if _check_instance_setup() and not _test:
             from lamindb_setup.core.django import reset_django
 
-            if settings._instance_exists:
-                raise CannotSwitchDefaultInstance(
-                    "Cannot init new instance after connecting to an existing instance."
-                )
             reset_django()
         elif _write_settings:
             disconnect(mute=True)


### PR DESCRIPTION
Also see:

- https://github.com/laminlabs/lamindb-setup/pull/1164