### PR TITLE
⬆️ Bump the lower bound on `aiobotocore` to 2.12.4 to allow `urllib` 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ Home = "https://github.com/laminlabs/lamindb-setup"
 
 [project.optional-dependencies]
 aws = [
-    "urllib3<2", # for botocore, TODO: check that really required
-    "aiobotocore[boto3]>=2.5.4,<3.0.0",
+    "aiobotocore[boto3]>=2.12.4,<3.0.0", # less problematic, supports urllib 2 via botocore bounds
     # exclude 2024.10.0 due to https://github.com/fsspec/s3fs/pull/910
     "s3fs>=2023.12.2,<=2025.7.0,!=2024.10.0"
 ]


### PR DESCRIPTION
Fix https://github.com/laminlabs/pfizer-lamin-usage/issues/455