### PR TITLE
🐛 Restore dynamic imports from `django` in `_schema_metadata`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           repository: laminlabs/laminhub
           token: ${{ secrets.GH_TOKEN_DEPLOY_LAMINAPP }}
           path: laminhub
-          ref: accountinstancetrigger
+          ref: main
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
@@ -132,7 +132,7 @@ jobs:
           repository: laminlabs/laminhub
           token: ${{ secrets.GH_TOKEN_DEPLOY_LAMINAPP }}
           path: laminhub
-          ref: accountinstancetrigger
+          ref: main
       - name: Set env file for local test of edge functions
         run: |
           touch .env.local


### PR DESCRIPTION
Otherwise deploying a migration after re-connect fails.