### PR TITLE
🐛 Reset aws s3 credentials cache after logout or re-login

### DIFF
--- a/lamindb_setup/_setup_user.py
+++ b/lamindb_setup/_setup_user.py
@@ -7,6 +7,7 @@ from lamin_utils import logger
 
 from ._check_setup import _check_instance_setup
 from ._init_instance import register_user
+from .core._aws_options import reset_aws_options_cache
 from .core._settings import settings
 from .core._settings_load import load_user_settings
 from .core._settings_save import save_user_settings
@@ -147,6 +148,8 @@ def login(
         register_user(user_settings)
 
     settings._user_settings = None
+    # aws s3 credentials are scoped to the user
+    reset_aws_options_cache()
     return user_settings
 
 
@@ -163,6 +166,8 @@ def logout():
     if current_user_settings_file().exists():
         current_user_settings_file().unlink()
         settings._user_settings = None
+        # aws s3 credentials are scoped to the user
+        reset_aws_options_cache()
         logger.success("logged out")
     else:
         logger.important("already logged out")

--- a/lamindb_setup/core/_aws_options.py
+++ b/lamindb_setup/core/_aws_options.py
@@ -245,3 +245,11 @@ def get_aws_options_manager() -> AWSOptionsManager:
         _aws_options_manager = AWSOptionsManager()
 
     return _aws_options_manager
+
+
+def reset_aws_options_cache():
+    global _aws_options_manager
+
+    if _aws_options_manager is not None:
+        _aws_options_manager._credentials_cache = {}
+        _aws_options_manager._parameters_cache = {}


### PR DESCRIPTION
Before it was possible to use credentials cached for one user with another user after re-login in the same python process.