### PR TITLE
🚸 Log when loading staging env

### DIFF
--- a/lamindb_setup/core/_aws_options.py
+++ b/lamindb_setup/core/_aws_options.py
@@ -20,6 +20,7 @@ lamin_env = os.getenv("LAMIN_ENV")
 if lamin_env is None or lamin_env == "prod":
     HOSTED_BUCKETS = tuple([f"s3://lamin-{region}" for region in HOSTED_REGIONS])
 else:
+    logger.warning("loaded LAMIN_ENV: staging")
     HOSTED_BUCKETS = ("s3://lamin-hosted-test",)  # type: ignore
 
 


### PR DESCRIPTION
Before | After
--- | ---
no info about `LAMIN_ENV` | <img width="290" height="49" alt="image" src="https://github.com/user-attachments/assets/cdf04d4f-86a0-494d-bb72-b20f9cdda05c" />
