### PR TITLE
🐛 Fix no mimetype for url in `get_stat_file_cloud`

### DIFF
--- a/lamindb_setup/core/upath.py
+++ b/lamindb_setup/core/upath.py
@@ -908,12 +908,9 @@ def get_stat_file_cloud(stat: dict) -> tuple[int, str | None, str | None]:
     elif "blob_id" in stat:
         hash = b16_to_b64(stat["blob_id"])
         hash_type = "sha1"
-    # s3
-    # StorageClass is checked to be sure that it is indeed s3
-    # because http also has ETag
     elif "ETag" in stat:
         etag = stat["ETag"]
-        if "mimetype" in stat:
+        if "mimetype" in stat or ("url" in stat and stat["url"].startswith("http")):
             # http
             hash = hash_string(etag.strip('"'))
             hash_type = "md5-etag"


### PR DESCRIPTION
Fix 
```
File ~/Documents/repos.nosync/laminhub/rest-hub/sub/lamindb/lamindb/models/artifact.py:315, in get_stat_or_artifact(path, storage, key, check_hash, is_replace, instance, skip_hash_lookup)
    313 stat = stat.as_info()
    314 if (store_type := stat["type"]) == "file":
--> 315     size, hash, hash_type = get_stat_file_cloud(stat)
    316 elif store_type == "directory":
    317     size, hash, hash_type, n_files = get_stat_dir_cloud(path)

File ~/Documents/repos.nosync/laminhub/rest-hub/sub/lamindb/sub/lamindb-setup/lamindb_setup/core/upath.py:932, in get_stat_file_cloud(stat)
    930             stripped_etag, suffix = etag.split("-")
    931             suffix = suffix.strip('"')
--> 932             hash = b16_to_b64(stripped_etag)
    933             hash_type = f"md5-{suffix}"  # this is the S3 chunk-hashing strategy
    934 if hash is not None:

File ~/Documents/repos.nosync/laminhub/rest-hub/sub/lamindb/sub/lamindb-setup/lamindb_setup/core/hashing.py:41, in b16_to_b64(s)
     40 def b16_to_b64(s: str):
---> 41     return to_b64_str(base64.b16decode(s.strip('"'), casefold=True))

File ~/miniconda3/envs/py311/lib/python3.11/base64.py:293, in b16decode(s, casefold)
    291 if re.search(b'[^0-9A-F]', s):
    292     raise binascii.Error('Non-base16 digit found')
--> 293 return binascii.unhexlify(s)

Error: Odd-length string
```
for https://ftp.ncbi.nlm.nih.gov/geo/series/GSE306nnn/GSE306429/suppl/GSE306429_combined_demuxed.h5ad



