### PR TITLE
🐛 Fix ArrowTypeError on export with NULL values in object columns

### DIFF
--- a/lamindb_setup/io.py
+++ b/lamindb_setup/io.py
@@ -78,7 +78,8 @@ def _export_full_table(
                     buffer,
                 )
             buffer.seek(0)
-            df = pd.read_csv(buffer)
+            # Prevent pandas from converting empty strings to float NaN (which PyArrow rejects)
+            df = pd.read_csv(buffer, keep_default_na=False)
             df.to_parquet(directory / f"{table_name}.parquet", compression=None)
             return (
                 f"{module_name}.{model_name}.{field_name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,4 +160,5 @@ filterwarnings = [
     "ignore:The 'verify' parameter is deprecated. Please configure it in the http client instead.:DeprecationWarning",
     "ignore:There is no current event loop:DeprecationWarning",
     "ignore:DateTimeField.*received a naive datetime.*while time zone support is active:RuntimeWarning",
+    "ignore::sqlalchemy.exc.SAWarning"
 ]


### PR DESCRIPTION
Fixed ArrowTypeError when exporting tables with mixed NULL and string values in object columns by adding keep_default_na=False to pd.read_csv(). This prevents pandas from converting empty CSV values to float NaN, which PyArrow's parquet writer rejects due to type inconsistency.

Encountered in `laminlabs/lamindata`