### PR TITLE
🔥 Remove logic that checks admin permissions client side before migrate step

### DIFF
--- a/lamindb_setup/_migrate.py
+++ b/lamindb_setup/_migrate.py
@@ -125,7 +125,6 @@ class migrate:
         from lamindb_setup._schema_metadata import update_schema_in_hub
         from lamindb_setup.core._hub_client import call_with_fallback_auth
         from lamindb_setup.core._hub_crud import (
-            select_collaborator,
             update_instance,
         )
 


### PR DESCRIPTION
This client-side "admin check" was not aware of access permissions gained through team membership. Because this is hard to keep in sync and maintain, removal seems the only sustainable solution.

If a user doesn't have permissions to migrate an instance (because they're not an admin), they'll now get a `PermissionError` raised through Django via the database.