### PR TITLE
🚸 Clarify vendor vs. dialect

### DIFF
--- a/lamindb_setup/core/_settings_instance.py
+++ b/lamindb_setup/core/_settings_instance.py
@@ -525,6 +525,7 @@ class InstanceSettings:
             assert self._db.startswith("postgresql"), f"Unexpected DB value: {self._db}"
             return "postgresql"
 
+    @property
     def vendor(self) -> Literal["sqlite", "postgresql"]:
         """Database vendor.
 

--- a/tests/hub-cloud/test_init_instance.py
+++ b/tests/hub-cloud/test_init_instance.py
@@ -91,6 +91,7 @@ def test_init_instance_postgres_default_name(get_hub_client):
     assert not ln_setup.settings.instance.storage.type_is_cloud
     assert ln_setup.settings.instance.owner == ln_setup.settings.user.handle
     assert ln_setup.settings.instance.dialect == "postgresql"
+    assert ln_setup.settings.instance.vendor == ln_setup.settings.instance.dialect
     assert ln_setup.settings.instance.db == pgurl
     assert (
         ln_setup.settings.instance.storage.root.as_posix()


### PR DESCRIPTION
Because of historically being based on SQLAlchemy, we still have the `.dialect` field. But given we Django conventions today it's more intuitive to use `.vendor` going forward.

We also have this convention in the lamindb unit tests in the env variable name: `LAMINDB_TEST_DB_VENDOR`.