### PR TITLE
♻️ Eliminate reference to `test-instance-private-postgres`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,6 @@ jobs:
       - run: nox -s lint
       - run: nox -s storage
         env:
-          TEST_INSTANCE_PRIVATE_POSTGRES: ${{ secrets.TEST_INSTANCE_PRIVATE_POSTGRES }}
           TMP_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           TMP_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - uses: actions/upload-artifact@v4

--- a/tests/storage/test_storage_access.py
+++ b/tests/storage/test_storage_access.py
@@ -23,11 +23,7 @@ def test_connect_instance_with_private_storage_and_no_storage_access():
         (ln_setup.settings.storage.root / "test_file").exists()
     # connecting to a postgres instance should work because it doesn't touch
     # storage during connection
-    ln_setup.connect(
-        "laminlabs/test-instance-private-postgres",
-        _db=os.environ["TEST_INSTANCE_PRIVATE_POSTGRES"],
-        _test=True,
-    )
+    ln_setup.connect("laminlabs/lamin-dev", _test=True)
     # accessing storage in the instance should fail:
     with pytest.raises(PermissionError):
         path = ln_setup.settings.storage.root


### PR DESCRIPTION
Internal [Slack thread](https://laminlabs.slack.com/archives/C062QDNMN6M/p1765178630789109).