### PR TITLE
🚸 Raise `SystemExit` upon `InstanceNotFound` only from CLI

### DIFF
--- a/lamindb_setup/errors.py
+++ b/lamindb_setup/errors.py
@@ -7,6 +7,7 @@
 .. autoexception:: InstanceLockedException
 .. autoexception:: SettingsEnvFileOutdated
 .. autoexception:: CannotSwitchDefaultInstance
+.. autoexception:: InstanceNotFoundError
 
 """
 
@@ -49,6 +50,10 @@ class StorageAlreadyManaged(Exception):
 class StorageNotEmpty(click.ClickException):
     def show(self, file=None):
         pass
+
+
+class InstanceNotFoundError(Exception):
+    pass
 
 
 # raise if a cloud SQLite instance is already locked


### PR DESCRIPTION
CLI:
```shell
% lamin connect laminlabs/doesnotexist
'laminlabs/doesnotexist' not found: 'instance-not-found'
Check your permissions: https://lamin.ai/laminlabs/doesnotexist
```

LaminDB:
```python
>>> import lamindb as ln
→ connected lamindb: laminlabs/lamindata
>>> ln.connect("laminlabs/doesnotexist")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/falexwolf/work/repos/laminhub/rest-hub/sub/lamindb/sub/lamindb-setup/lamindb_setup/core/cloud_sqlite_locker.py", line 233, in wrapper
    raise exc
  File "/Users/falexwolf/work/repos/laminhub/rest-hub/sub/lamindb/sub/lamindb-setup/lamindb_setup/core/cloud_sqlite_locker.py", line 228, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/falexwolf/work/repos/laminhub/rest-hub/sub/lamindb/sub/lamindb-setup/lamindb_setup/_connect_instance.py", line 411, in connect
    raise e
  File "/Users/falexwolf/work/repos/laminhub/rest-hub/sub/lamindb/sub/lamindb-setup/lamindb_setup/_connect_instance.py", line 365, in connect
    raise e
  File "/Users/falexwolf/work/repos/laminhub/rest-hub/sub/lamindb/sub/lamindb-setup/lamindb_setup/_connect_instance.py", line 355, in connect
    isettings = _connect_instance(
                ^^^^^^^^^^^^^^^^^^
  File "/Users/falexwolf/work/repos/laminhub/rest-hub/sub/lamindb/sub/lamindb-setup/lamindb_setup/_connect_instance.py", line 173, in _connect_instance
    raise exception
lamindb_setup.errors.InstanceNotFoundError: 'laminlabs/doesnotexist' not found: 'instance-not-found'
Check your permissions: https://lamin.ai/laminlabs/doesnotexist
```