### PR TITLE
🚸 Remove duplicated logging in `ln.connect()` if already connected

### DIFF
--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -304,9 +304,8 @@ def validate_connection_state(
                 raise CannotSwitchDefaultInstance(
                     "Cannot switch default instance while `ln.track()` is live: call `ln.finish()`"
                 )
-            logger.warning("re-setting django")
-            logger.important_hint(
-                "avoid this by clearing the default instance on the command line via: lamin disconnect"
+            logger.warning(
+                "re-setting django: avoid this by clearing the default instance on the command line via: lamin disconnect"
             )
             reset_django()
             did_reset_django = True

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -273,13 +273,27 @@ def _connect_cli(
 
 def validate_connection_state(
     owner: str, name: str, use_root_db_user: bool = False, init: bool = False
-) -> bool:
+) -> tuple[bool, bool]:
+    """Inspect current setup state before connecting.
+
+    Returns:
+        A tuple `(did_reset_django, already_connected)`.
+
+        - `(False, True)`: already connected to the requested default instance;
+          caller can suppress duplicate "connected" logging while still running reconnect
+          side effects.
+        - `(True, False)`: Django was reset and caller should continue connect flow.
+        - `(False, False)`: no reset was needed and caller should continue connect flow.
+    """
+    did_reset_django = False
+    already_connected = False
+
     if (
         settings._instance_exists  # exists only for real instances, not for none/none
         and f"{owner}/{name}" == settings.instance.slug
         and not use_root_db_user  # always re-connect for root db user
     ):
-        return False
+        already_connected = True
     else:
         # settings._instance_exists: exists only for real instances, not for none/none
         # in case of init, we'd like to reset django for now
@@ -295,8 +309,8 @@ def validate_connection_state(
                 "avoid this by clearing the default instance on the command line via: lamin disconnect"
             )
             reset_django()
-            return True
-    return False
+            did_reset_django = True
+    return did_reset_django, already_connected
 
 
 @unlock_cloud_sqlite_upon_exception(ignore_prev_locker=True)
@@ -339,6 +353,7 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
 
     isettings: InstanceSettings = None  # type: ignore
     did_reset_django = False
+    suppress_connected_log = False
 
     access_token: str | None = None
     _user: UserSettings | None = kwargs.get("_user", None)
@@ -365,7 +380,7 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
         else:
             owner, name = get_owner_name_from_identifier(instance)
             if _check_instance_setup() and not _test:
-                did_reset_django = validate_connection_state(
+                did_reset_django, suppress_connected_log = validate_connection_state(
                     owner, name, use_root_db_user=use_root_db_user
                 )
             elif (
@@ -428,7 +443,7 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
             reset_django_module_variables()
 
         slug = isettings.slug
-        if slug != "none/none":
+        if slug != "none/none" and not suppress_connected_log:
             logger.important(f"connected lamindb: {slug}")
             if isettings.dialect == "postgresql" and "public" in isettings.db:
                 logger.warning(

--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -279,9 +279,6 @@ def validate_connection_state(
         and f"{owner}/{name}" == settings.instance.slug
         and not use_root_db_user  # always re-connect for root db user
     ):
-        logger.important(
-            f"doing nothing, already connected lamindb: {settings.instance.slug}"
-        )
         return False
     else:
         # settings._instance_exists: exists only for real instances, not for none/none

--- a/lamindb_setup/_init_instance.py
+++ b/lamindb_setup/_init_instance.py
@@ -286,7 +286,7 @@ def init(
         if instance_state == "connected":
             return None
         if _check_instance_setup() and not _test:
-            did_reset_django = validate_connection_state(
+            did_reset_django, _ = validate_connection_state(
                 user_handle, name_str, init=True
             )
         elif _write_settings:

--- a/tests/core/test_connect_routing.py
+++ b/tests/core/test_connect_routing.py
@@ -91,7 +91,8 @@ def test_validate_connection_state_connected_instance_resets(monkeypatch):
     assert did_reset is True
     assert already_connected is False
     assert called["reset"] == 1
-    assert warning_calls == ["re-setting django"]
+    assert len(warning_calls) == 1
+    assert warning_calls[0].startswith("re-setting django")
 
 
 def test_connect_rewrites_module_vars_only_after_reset(monkeypatch):

--- a/tests/core/test_connect_routing.py
+++ b/tests/core/test_connect_routing.py
@@ -54,9 +54,12 @@ def test_validate_connection_state_none_none_skips_reset(monkeypatch):
         connect_instance, "reset_django", lambda: called.__setitem__("reset", 1)
     )
 
-    did_reset = connect_instance.validate_connection_state("owner", "name")
+    did_reset, already_connected = connect_instance.validate_connection_state(
+        "owner", "name"
+    )
 
     assert did_reset is False
+    assert already_connected is False
     assert called["reset"] == 0
 
 
@@ -81,9 +84,12 @@ def test_validate_connection_state_connected_instance_resets(monkeypatch):
         "warning",
         lambda message: warning_calls.append(message),
     )
-    did_reset = connect_instance.validate_connection_state("owner", "new")
+    did_reset, already_connected = connect_instance.validate_connection_state(
+        "owner", "new"
+    )
 
     assert did_reset is True
+    assert already_connected is False
     assert called["reset"] == 1
     assert warning_calls == ["re-setting django"]
 
@@ -111,7 +117,7 @@ def test_connect_rewrites_module_vars_only_after_reset(monkeypatch):
     monkeypatch.setattr(
         connect_instance,
         "validate_connection_state",
-        lambda owner, name, use_root_db_user=False: False,
+        lambda owner, name, use_root_db_user=False: (False, False),
     )
     connect_instance.connect("owner/name", _reload_lamindb=True)
     assert rewrite_calls["n"] == 0
@@ -119,7 +125,7 @@ def test_connect_rewrites_module_vars_only_after_reset(monkeypatch):
     monkeypatch.setattr(
         connect_instance,
         "validate_connection_state",
-        lambda owner, name, use_root_db_user=False: True,
+        lambda owner, name, use_root_db_user=False: (True, False),
     )
     connect_instance.connect("owner/name", _reload_lamindb=True)
     assert rewrite_calls["n"] == 1


### PR DESCRIPTION
Reduces the number of log events during `ln.connect()` if already connected.