### PR TITLE
🐛 Use `access_token` in `get_default_bucket_for_instance` in `init_storage`

### DIFF
--- a/lamindb_setup/core/_settings_storage.py
+++ b/lamindb_setup/core/_settings_storage.py
@@ -166,7 +166,9 @@ def init_storage(
             assert "--" in root_str, "example: `create-s3--eu-central-1`"
             region = root_str.replace("create-s3--", "")
         bucket = get_default_bucket_for_instance(
-            None if init_instance else instance_id, region
+            None if init_instance else instance_id,
+            region,
+            access_token=access_token,
         )
         root = f"{bucket}/{uid}"
     elif (input_protocol := fsspec.utils.get_protocol(root_str)) not in VALID_PROTOCOLS:


### PR DESCRIPTION
Even if `access_token` was passed to `init_storage`, it wasn't used in `get_default_bucket_for_instance`. This PR fixes the bug.