### PR TITLE
🐛 Use etag for gs when md5 hash is not available, do consistent hashing of cloud directories

### DIFF
--- a/lamindb_setup/core/upath.py
+++ b/lamindb_setup/core/upath.py
@@ -1233,8 +1233,8 @@ def get_stat_file_cloud(stat: dict, protocol: str, accessor: str | None = None):
         assert accessor in stat
         hash_candidate = stat[accessor].strip('"=')
         if accessor == "md5Hash":
-            # on gs md5 hash is already in base64
-            hash = hash_candidate
+            # on gs md5 hash is already in base64, convert to b64url
+            hash = hash_candidate.replace("+", "-").replace("/", "_")
             hash_type = "md5"
         else:
             # gs etag is an opaque string, better to hash it

--- a/lamindb_setup/core/upath.py
+++ b/lamindb_setup/core/upath.py
@@ -1285,7 +1285,7 @@ def get_stat_dir_cloud(path: UPath) -> tuple[int, str | None, str | None, int]:
     if protocol == "s3":
         accessor = "ETag"
     elif protocol == "gs":
-        accessor = "etag"
+        accessor = None  # use md5Hash or etag depending on what is available
     elif protocol == "hf":
         accessor = "blob_id"
     else:

--- a/lamindb_setup/core/upath.py
+++ b/lamindb_setup/core/upath.py
@@ -1222,38 +1222,56 @@ def fs_for_moving(
     )
 
 
-def get_stat_file_cloud(stat: dict) -> tuple[int, str | None, str | None]:
+def get_stat_file_cloud(stat: dict, protocol: str, accessor: str | None = None):
     size = stat["size"]
     hash, hash_type = None, None
-    # gs, use md5Hash instead of etag for now
-    if "md5Hash" in stat:
-        # gs hash is already in base64
-        hash = stat["md5Hash"].strip('"=')
-        hash_type = "md5"
-    # hf
-    elif "blob_id" in stat:
-        hash = b16_to_b64(stat["blob_id"])
-        hash_type = "sha1"
-    elif "ETag" in stat:
-        etag = stat["ETag"]
-        if "mimetype" in stat or ("url" in stat and stat["url"].startswith("http")):
-            # http
-            hash = hash_string(etag.strip('"'))
-            hash_type = "md5-etag"
+    if protocol == "gs":
+        if accessor is None:
+            accessor = "md5Hash" if "md5Hash" in stat else "etag"
         else:
-            # s3
-            # small files
-            if "-" not in etag:
-                # only store hash for non-multipart uploads
-                # we can't rapidly validate multi-part uploaded files client-side
-                # we can add more logic later down-the-road
-                hash = b16_to_b64(etag)
-                hash_type = "md5"
-            else:
-                stripped_etag, suffix = etag.split("-")
-                suffix = suffix.strip('"')
-                hash = b16_to_b64(stripped_etag)
-                hash_type = f"md5-{suffix}"  # this is the S3 chunk-hashing strategy
+            assert accessor in {"md5Hash", "etag"}
+        assert accessor in stat
+        # gs md5 hash and etag are already in base64
+        hash = stat[accessor].strip('"=')
+        if accessor == "md5Hash":
+            hash_type = "md5"
+        else:
+            hash_type = "etag"
+    elif protocol == "s3":
+        if accessor is None:
+            accessor = "ETag"
+        else:
+            assert accessor == "ETag"
+        assert accessor in stat
+        etag = stat[accessor].strip('"=')
+        if "-" not in etag:
+            # only store hash for non-multipart uploads
+            # we can't rapidly validate multi-part uploaded files client-side
+            # we can add more logic later down-the-road
+            hash = b16_to_b64(etag)
+            hash_type = "md5"
+        else:
+            stripped_etag, suffix = etag.split("-")
+            hash = b16_to_b64(stripped_etag)
+            hash_type = f"md5-{suffix}"  # this is the S3 chunk-hashing strategy
+    elif protocol == "hf":
+        if accessor is None:
+            accessor = "blob_id"
+        else:
+            assert accessor == "blob_id"
+        assert accessor in stat
+        hash = b16_to_b64(stat[accessor])
+        hash_type = "sha1"
+    elif protocol in {"http", "https"}:
+        if accessor is None:
+            accessor = "ETag"
+        else:
+            assert accessor == "ETag"
+        assert accessor in stat
+        etag = stat[accessor].strip('"=')
+        hash = hash_string(etag)
+        hash_type = "md5-etag"
+
     if hash is not None:
         hash = hash[:HASH_LENGTH]
     return size, hash, hash_type
@@ -1261,22 +1279,26 @@ def get_stat_file_cloud(stat: dict) -> tuple[int, str | None, str | None]:
 
 def get_stat_dir_cloud(path: UPath) -> tuple[int, str | None, str | None, int]:
     objects = path.fs.find(path.as_posix(), detail=True)
+    protocol = path.protocol
     hash, hash_type = None, None
     compute_list_hash = True
-    if path.protocol == "s3":
+    if protocol == "s3":
         accessor = "ETag"
-    elif path.protocol == "gs":
-        accessor = "md5Hash"
-    elif path.protocol == "hf":
+    elif protocol == "gs":
+        accessor = "etag"
+    elif protocol == "hf":
         accessor = "blob_id"
     else:
         compute_list_hash = False
     sizes = []
     hashes = []
     for object in objects.values():
-        sizes.append(object["size"])
         if compute_list_hash:
-            hashes.append(object[accessor].strip('"='))
+            size, hash, _ = get_stat_file_cloud(object, protocol, accessor)
+            sizes.append(size)
+            hashes.append(hash)
+        else:
+            sizes.append(object["size"])
     size = sum(sizes)
     n_files = len(sizes)
     if compute_list_hash:

--- a/lamindb_setup/core/upath.py
+++ b/lamindb_setup/core/upath.py
@@ -1231,12 +1231,15 @@ def get_stat_file_cloud(stat: dict, protocol: str, accessor: str | None = None):
         else:
             assert accessor in {"md5Hash", "etag"}
         assert accessor in stat
-        # gs md5 hash and etag are already in base64
-        hash = stat[accessor].strip('"=')
+        hash_candidate = stat[accessor].strip('"=')
         if accessor == "md5Hash":
+            # on gs md5 hash is already in base64
+            hash = hash_candidate
             hash_type = "md5"
         else:
-            hash_type = "etag"
+            # gs etag is an opaque string, better to hash it
+            hash = hash_string(hash_candidate)
+            hash_type = "md5-etag"
     elif protocol == "s3":
         if accessor is None:
             accessor = "ETag"

--- a/tests/core/test_storage_stats.py
+++ b/tests/core/test_storage_stats.py
@@ -13,7 +13,7 @@ from lamindb_setup.core.upath import (
 def test_get_stat_file_cloud_aws():
     string_path = "s3://bionty-assets/df_all__ncbitaxon__2023-06-20__Organism.parquet"
     path = UPath(string_path, anon=True)
-    size, hash, hash_type = get_stat_file_cloud(path.stat().as_info())
+    size, hash, hash_type = get_stat_file_cloud(path.stat().as_info(), "s3")
     assert hash == "zQxieeCkNGNJWhPl3OfM8A"
     assert hash_type == "md5-5"
     assert size == 78148228
@@ -22,7 +22,7 @@ def test_get_stat_file_cloud_aws():
 def test_get_stat_file_cloud_gcp():
     string_path = "gs://rxrx1-europe-west4/images/test/HEPG2-08/Plate1/B02_s1_w1.png"
     path = UPath(string_path)
-    size, hash, hash_type = get_stat_file_cloud(path.stat().as_info())
+    size, hash, hash_type = get_stat_file_cloud(path.stat().as_info(), "gs")
     assert hash == "foEgLjmuUHO62CazxN97rA"
     assert hash_type == "md5"
     assert size == 65122
@@ -31,7 +31,7 @@ def test_get_stat_file_cloud_gcp():
 def test_get_stat_file_cloud_hf():
     string_path = "hf://datasets/Koncopd/lamindb-test/anndata/pbmc68k_test.h5ad"
     path = UPath(string_path)
-    size, hash, hash_type = get_stat_file_cloud(path.stat().as_info())
+    size, hash, hash_type = get_stat_file_cloud(path.stat().as_info(), "hf")
     assert hash == "zY4nvir5FtTHY2f0GKn9Ac"
     assert hash_type == "sha1"
     assert size == 267036
@@ -40,7 +40,7 @@ def test_get_stat_file_cloud_hf():
 def test_get_stat_file_cloud_http():
     string_path = "https://raw.githubusercontent.com/laminlabs/lamindb-setup/refs/heads/main/README.md"
     path = UPath(string_path)
-    size, hash, hash_type = get_stat_file_cloud(path.stat().as_info())
+    size, hash, hash_type = get_stat_file_cloud(path.stat().as_info(), "https")
     assert hash == "h3XDCTkMambmtSVpTQetLQ"
     assert hash_type == "md5-etag"
     assert size == 272

--- a/tests/core/test_storage_stats.py
+++ b/tests/core/test_storage_stats.py
@@ -70,7 +70,7 @@ def test_get_stat_dir_cloud_md5_gcp():
     path = UPath(string_path)
     size, hash, hash_type, n_files = get_stat_dir_cloud(path)
     assert n_files == 14772
-    assert hash == "6r5Hkce0UTy7X6gLeaqzBA"
+    assert hash == "91wp4sNOCUyeK7kOEz3MiQ"
     assert hash_type == "md5-d"
     assert size == 994441606
 
@@ -80,7 +80,7 @@ def test_get_stat_dir_cloud_md5_etag_mix_gcp():
     path = UPath(string_path)
     size, hash, hash_type, n_files = get_stat_dir_cloud(path)
     assert n_files == 16
-    assert hash == "iyZBAWghUNhoWQGn_cZ3IQ"
+    assert hash == "Fjx0d6ZUx2e6ZMOUFJF0pw"
     assert hash_type == "md5-d"
     assert size == 29900066409
 

--- a/tests/core/test_storage_stats.py
+++ b/tests/core/test_storage_stats.py
@@ -52,7 +52,7 @@ def test_get_stat_dir_cloud_aws():
     _, n_files_file_tree = compute_file_tree(path)
     size, hash, hash_type, n_files = get_stat_dir_cloud(path)
     assert n_files == n_files_file_tree
-    assert hash == "IVKGMfNwi8zKvnpaD_gG7w"
+    assert hash == "b4mOx8qRVGKmI2-4tw2WCw"
     assert hash_type == "md5-d"
     assert size == 658465
     assert n_files == 51
@@ -73,7 +73,7 @@ def test_get_stat_dir_cloud_hf():
     path = UPath(string_path)
     size, hash, hash_type, n_files = get_stat_dir_cloud(path)
     assert n_files == 11
-    assert hash == "oj6I3nNKj_eiX2I1q26qaw"
+    assert hash == "YgK4yrGwOzZgTejMxR7Gnw"
     assert hash_type == "md5-d"
     assert size == 42767
 

--- a/tests/core/test_storage_stats.py
+++ b/tests/core/test_storage_stats.py
@@ -22,9 +22,16 @@ def test_get_stat_file_cloud_aws():
 def test_get_stat_file_cloud_gcp():
     string_path = "gs://rxrx1-europe-west4/images/test/HEPG2-08/Plate1/B02_s1_w1.png"
     path = UPath(string_path)
-    size, hash, hash_type = get_stat_file_cloud(path.stat().as_info(), "gs")
+    stat = path.stat().as_info()
+
+    size, hash, hash_type = get_stat_file_cloud(stat, "gs")  # has md5 hash
     assert hash == "foEgLjmuUHO62CazxN97rA"
     assert hash_type == "md5"
+    assert size == 65122
+
+    size, hash, hash_type = get_stat_file_cloud(stat, "gs", accessor="etag")
+    assert hash == "U0nhcxsfh69UcNZ9ITiWhA"
+    assert hash_type == "md5-etag"
     assert size == 65122
 
 
@@ -58,7 +65,7 @@ def test_get_stat_dir_cloud_aws():
     assert n_files == 51
 
 
-def test_get_stat_dir_cloud_gcp():
+def test_get_stat_dir_cloud_md5_gcp():
     string_path = "gs://rxrx1-europe-west4/images/test/HEPG2-08"
     path = UPath(string_path)
     size, hash, hash_type, n_files = get_stat_dir_cloud(path)
@@ -66,6 +73,16 @@ def test_get_stat_dir_cloud_gcp():
     assert hash == "6r5Hkce0UTy7X6gLeaqzBA"
     assert hash_type == "md5-d"
     assert size == 994441606
+
+
+def test_get_stat_dir_cloud_md5_etag_mix_gcp():
+    string_path = "gs://arc-institute-virtual-cell-atlas/scbasecount/2026-01-12/star_references/Macaca_mulatta/MMUL-10"
+    path = UPath(string_path)
+    size, hash, hash_type, n_files = get_stat_dir_cloud(path)
+    assert n_files == 16
+    assert hash == "iyZBAWghUNhoWQGn_cZ3IQ"
+    assert hash_type == "md5-d"
+    assert size == 29900066409
 
 
 def test_get_stat_dir_cloud_hf():


### PR DESCRIPTION
For some objects on gs md5 hash is not available, now we use etag in this case.

Also fixes inconsistencies with `md5Hash` encoding for gs, encodings for source hashes for cloud directories.