### PR TITLE
🚸 Print warnings on instance module mismatch with environment during `ln.connect()` and `ln.DB()`

### DIFF
--- a/lamindb_setup/_connect_instance.py
+++ b/lamindb_setup/_connect_instance.py
@@ -422,6 +422,7 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
         if _test:
             return None
         silence_loggers()
+        settings.modules_warning = None
         check, msg = isettings._load_db()
         if not check:
             local_db = (
@@ -456,6 +457,8 @@ def connect(instance: str | None = None, **kwargs: Any) -> str | tuple | None:
                 logger.warning(
                     f'connected in read-only mode, please use ln.DB("{slug}") instead'
                 )
+            if settings.modules_warning is not None:
+                logger.warning(settings.modules_warning)
     except Exception as e:
         if isettings is not None:
             if _write_settings:

--- a/lamindb_setup/core/_settings.py
+++ b/lamindb_setup/core/_settings.py
@@ -452,9 +452,9 @@ class SetupSettings:
             repr += f"{colors.cyan('Instance:')} None"
         modules_schema_str = ",".join(sorted(self.modules))
         modules_display = modules_schema_str if modules_schema_str != "" else '""'
-        repr += f"\n{colors.blue('Cache & settings:')}\n"
-        repr += f" - cache: {self.cache_dir.as_posix()}\n"
+        repr += f"\n{colors.blue('Settings:')}\n"
         repr += f" - modules: {modules_display}\n"
+        repr += f" - cache: {self.cache_dir.as_posix()}\n"
         repr += f" - user settings: {settings_dir.as_posix()}\n"
         repr += f" - system settings: {system_settings_dir.as_posix()}"
         repr += f"\n{colors.green('User:')} {self.user.handle}"

--- a/lamindb_setup/core/django.py
+++ b/lamindb_setup/core/django.py
@@ -262,17 +262,19 @@ def _warn_module_mismatch(target_apps: set[str], current_apps: set[str]) -> str 
     additional_apps = sorted(target_apps - current_apps)
     details: list[str] = []
     if additional_apps:
-        details.append(f"has non-configured modules: {', '.join(additional_apps)}")
+        details.append(
+            f"has non-configured modules: {','.join(additional_apps)}"
+        )  # no white space after comma for consistency
     if missing_apps:
         if additional_apps:
             details.append("and")
         details.append(
-            f"does not have some of your locally configured modules: {', '.join(missing_apps)}"
+            f"does not have some of your locally configured modules: {','.join(missing_apps)}"  # no white space after comma for consistency
         )
     if missing_apps:
         hint = "you will run into an error when trying to permanently delete objects that are related to objects in these modules"
     if additional_apps:
-        hint = f"you can only query modules that are configured in your environment"
+        hint = f"you can only query entities (registries, fields) from modules that are configured in your environment"
     modules_for_hint = sorted(app for app in target_apps if app != "lamindb")
     modules_arg = ",".join(modules_for_hint) if modules_for_hint else '""'
     hint2 = (

--- a/tests/core/test_connect_routing.py
+++ b/tests/core/test_connect_routing.py
@@ -132,6 +132,37 @@ def test_connect_rewrites_module_vars_only_after_reset(monkeypatch):
     assert rewrite_calls["n"] == 1
 
 
+def test_connect_prints_modules_warning(monkeypatch):
+    fake_isettings = _FakeConnectedInstance()
+    monkeypatch.setattr(connect_instance, "_check_instance_setup", lambda: False)
+    monkeypatch.setattr(
+        connect_instance,
+        "_connect_instance",
+        lambda *args, **kwargs: fake_isettings,
+    )
+    monkeypatch.setattr(connect_instance, "silence_loggers", lambda: None)
+    monkeypatch.setattr(
+        connect_instance, "load_from_isettings", lambda *args, **kwargs: None
+    )
+
+    def _load_db_with_modules_warning() -> tuple[bool, str]:
+        connect_instance.settings.modules_warning = "module mismatch warning"
+        return True, ""
+
+    monkeypatch.setattr(fake_isettings, "_load_db", _load_db_with_modules_warning)
+
+    warning_calls: list[str] = []
+    monkeypatch.setattr(
+        connect_instance.logger,
+        "warning",
+        lambda message: warning_calls.append(message),
+    )
+
+    connect_instance.connect("owner/name", _reload_lamindb=False)
+
+    assert "module mismatch warning" in warning_calls
+
+
 def test_module_mismatch_warning_includes_modules_command():
     message = django_core._warn_module_mismatch(
         target_apps={"lamindb", "bionty"},


### PR DESCRIPTION
See:

- https://github.com/laminlabs/lamindb/pull/3699